### PR TITLE
ci: Add GitHub Actions workflow for linting and testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  lint:
+    name: Lint (ShellCheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          # Scan everything by default (finds .sh and sh/bash shebangs)
+          severity: warning
+  
+  test:
+    name: Integration Test (Mock)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install dependencies
+        run: sudo apt-get install -y curl jq
+
+      - name: Verify executable
+        run: |
+          if [ -f "bin/altertable" ]; then
+            chmod +x bin/altertable
+            ./bin/altertable --version
+            ./bin/altertable --help
+          else
+            echo "Binary not found, skipping (workflow-only PR)"
+          fi


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that runs `shellcheck` (linting) and basic tests on the repository. It's intended to be merged first so that future branches can rely on it for CI/CD checks.

## Checks
- [x] Linting with `shellcheck` (via `ludeeus/action-shellcheck`)
- [x] Basic script execution test