### PR TITLE
fix: use http_request in cmd_validate to handle errors gracefully

### DIFF
--- a/bin/altertable
+++ b/bin/altertable
@@ -241,26 +241,7 @@ cmd_validate() {
     local payload="{\"statement\": \"${safe_statement}\"}"
   fi
   
-  local response
-  local url="${ALTERTABLE_API_BASE:-$API_BASE}/validate"
-  local auth_header
-  if [[ -n "${ALTERTABLE_BASIC_AUTH_TOKEN}" ]]; then
-     auth_header="Authorization: Basic ${ALTERTABLE_BASIC_AUTH_TOKEN}"
-  elif [[ -n "${ALTERTABLE_USERNAME}" && -n "${ALTERTABLE_PASSWORD}" ]]; then
-     local token
-     token=$(echo -n "${ALTERTABLE_USERNAME}:${ALTERTABLE_PASSWORD}" | base64 | tr -d '\n')
-     auth_header="Authorization: Basic ${token}"
-  fi
-
-  response=$(curl -s -X POST -H "${auth_header}" -H "User-Agent: ${USER_AGENT}" \
-       -H "Content-Type: application/json" \
-       -d "${payload}" "${url}")
-
-  if command -v jq >/dev/null 2>&1; then
-     echo "${response}" | jq .
-  else
-     echo "${response}"
-  fi
+  http_request "POST" "/validate" "${payload}" "Content-Type: application/json"
 }
 
 urlencode() {


### PR DESCRIPTION
This PR updates `cmd_validate` to use the `http_request` wrapper introduced in #4. This ensures that validation errors (e.g. auth failures, 400s) are handled gracefully instead of piping raw error text to `jq`.