### PR TITLE
feat: add configure command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,5 +72,8 @@ jobs:
           ./bin/altertable --version
           ./bin/altertable --help
 
+      - name: Run Configure Tests
+        run: ./tests/configure_test.sh
+
       - name: Run Integration Tests
         run: ./tests/integration_test.sh

--- a/README.md
+++ b/README.md
@@ -19,37 +19,37 @@ chmod +x /usr/local/bin/altertable
 
 ## Configuration
 
-The fastest way to get set up is `altertable configure`, which stores credentials
-securely (OS keychain when available, otherwise a `0600` file under
-`~/.config/altertable`).
+`altertable configure` stores a credential securely. It holds **one** credential at a
+time — each `configure` **replaces** the previous one, so authentication mechanisms are
+never combined.
 
 ```bash
-# Lakehouse credentials (global — the environment is derived from the credential).
-# Run with no flags to be prompted (password input is hidden):
+# Lakehouse username/password. With no flags you're prompted (password input is hidden):
 altertable configure
-
-# Or pass them directly (prefer the prompt or --password-stdin to keep secrets out of shell history):
 altertable configure --user your_username --password your_password
 printf '%s' "$PASSWORD" | altertable configure --user your_username --password-stdin
 
-# Management API key (per environment):
+# ...or a pre-encoded HTTP Basic token:
+altertable configure --basic-token "$(printf '%s' user:pass | base64)"
+
+# ...or a management API key for a given environment:
 altertable configure --api-key atm_xxxx --env production
 printf '%s' "$KEY" | altertable configure --api-key-stdin --env production
 
 # Inspect (secrets are masked) and remove:
 altertable configure --list
-altertable configure --remove --env production
-altertable configure --remove --lakehouse
-altertable configure --remove --all
+altertable configure --remove
 ```
 
 Where things are stored:
 
-- **Non-secret config** (username, base URLs, default env): `~/.config/altertable/config`.
-- **Secrets** (password, API keys, Basic token): the OS keychain — macOS Keychain
-  (`security`) or Linux libsecret (`secret-tool`) — or, if neither is present,
-  `~/.config/altertable/credentials` (`chmod 600`). Force a backend with
-  `ALTERTABLE_SECRET_BACKEND=keychain|file`.
+- **Non-secret config** (username, api-key environment): `~/.config/altertable/config`.
+- **Secret** (password, Basic token, or API key): the **macOS Keychain** when available,
+  otherwise a `~/.config/altertable/credentials` file with `chmod 600`. Force a backend
+  with `ALTERTABLE_SECRET_BACKEND=keychain|file`. `altertable configure --list` shows
+  which is in use (`MacOS keychain` or the file path). For security, the CLI **refuses to
+  read the credentials file if its permissions are looser than `600`** — run
+  `chmod 600 ~/.config/altertable/credentials` if prompted.
 
 Credential precedence (highest first): environment variables
 (`ALTERTABLE_BASIC_AUTH_TOKEN`, `ALTERTABLE_LAKEHOUSE_USERNAME`/`_PASSWORD`) →

--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ altertable configure --basic-token "$(printf '%s' user:pass | base64)"
 altertable configure --api-key atm_xxxx --env production
 printf '%s' "$KEY" | altertable configure --api-key-stdin --env production
 
-# Inspect (secrets are masked), remove (prompts), or clear everything (no prompt):
-altertable configure --list
-altertable configure --remove
+# Inspect (secrets are masked) or clear everything (no prompt):
+altertable configure --show
 altertable configure --clear
 ```
 
@@ -47,7 +46,7 @@ Where things are stored:
 - **Non-secret config** (username, api-key environment): `~/.config/altertable/config`.
 - **Secret** (password, Basic token, or API key): the **macOS Keychain** when available,
   otherwise a `~/.config/altertable/credentials` file with `chmod 600`. Force a backend
-  with `ALTERTABLE_SECRET_BACKEND=keychain|file`. `altertable configure --list` shows
+  with `ALTERTABLE_SECRET_BACKEND=keychain|file`. `altertable configure --show` shows
   which is in use (`MacOS keychain` or the file path). For security, the CLI **refuses to
   read the credentials file if its permissions are looser than `600`** — run
   `chmod 600 ~/.config/altertable/credentials` if prompted.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,41 @@ chmod +x /usr/local/bin/altertable
 
 ## Configuration
 
-Set the following environment variables for authentication:
+The fastest way to get set up is `altertable configure`, which stores credentials
+securely (OS keychain when available, otherwise a `0600` file under
+`~/.config/altertable`).
+
+```bash
+# Lakehouse credentials (global — the environment is derived from the credential).
+# Run with no flags to be prompted (password input is hidden):
+altertable configure
+
+# Or pass them directly (prefer the prompt or --password-stdin to keep secrets out of shell history):
+altertable configure --user your_username --password your_password
+printf '%s' "$PASSWORD" | altertable configure --user your_username --password-stdin
+
+# Management API key (per environment):
+altertable configure --api-key atm_xxxx --env production
+printf '%s' "$KEY" | altertable configure --api-key-stdin --env production
+
+# Inspect (secrets are masked) and remove:
+altertable configure --list
+altertable configure --remove --env production
+altertable configure --remove --lakehouse
+altertable configure --remove --all
+```
+
+Where things are stored:
+
+- **Non-secret config** (username, base URLs, default env): `~/.config/altertable/config`.
+- **Secrets** (password, API keys, Basic token): the OS keychain — macOS Keychain
+  (`security`) or Linux libsecret (`secret-tool`) — or, if neither is present,
+  `~/.config/altertable/credentials` (`chmod 600`). Force a backend with
+  `ALTERTABLE_SECRET_BACKEND=keychain|file`.
+
+Credential precedence (highest first): environment variables
+(`ALTERTABLE_BASIC_AUTH_TOKEN`, `ALTERTABLE_LAKEHOUSE_USERNAME`/`_PASSWORD`) →
+stored configuration. This keeps CI and scripted usage working unchanged:
 
 ```bash
 export ALTERTABLE_LAKEHOUSE_USERNAME="your_lakehouse_username"

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ altertable configure --basic-token "$(printf '%s' user:pass | base64)"
 altertable configure --api-key atm_xxxx --env production
 printf '%s' "$KEY" | altertable configure --api-key-stdin --env production
 
-# Inspect (secrets are masked) and remove:
+# Inspect (secrets are masked), remove (prompts), or clear everything (no prompt):
 altertable configure --list
 altertable configure --remove
+altertable configure --clear
 ```
 
 Where things are stored:

--- a/bin/altertable
+++ b/bin/altertable
@@ -78,21 +78,6 @@ altertable_usage() {
     echo
 
     # :environment_variable.usage
-    printf "  %s\n" "ALTERTABLE_APP_BASE"
-    printf "    Management API Base URL (default: https://app.altertable.ai)\n"
-    echo
-
-    # :environment_variable.usage
-    printf "  %s\n" "ALTERTABLE_API_KEY"
-    printf "    Management API key (overrides stored value)\n"
-    echo
-
-    # :environment_variable.usage
-    printf "  %s\n" "ALTERTABLE_ENV"
-    printf "    Default environment for management operations\n"
-    echo
-
-    # :environment_variable.usage
     printf "  %s\n" "ALTERTABLE_CONFIG_HOME"
     printf "    Config/credentials directory (default: $XDG_CONFIG_HOME/altertable)\n"
     echo
@@ -429,41 +414,13 @@ altertable_configure_usage() {
     echo
 
     # :flag.usage
-    printf "  %s\n" "--default"
-    printf "    Mark the --env environment as the default\n"
-    printf "    %s\n" "Needs: --env"
-    echo
-
-    # :flag.usage
-    printf "  %s\n" "--api-base URL"
-    printf "    Override the data-plane base URL\n"
-    echo
-
-    # :flag.usage
-    printf "  %s\n" "--app-base URL"
-    printf "    Override the management base URL\n"
-    echo
-
-    # :flag.usage
     printf "  %s\n" "--list"
     printf "    Show stored configuration (secrets masked)\n"
     echo
 
     # :flag.usage
     printf "  %s\n" "--remove"
-    printf "    Remove stored credentials (with --env, --lakehouse, or --all)\n"
-    echo
-
-    # :flag.usage
-    printf "  %s\n" "--lakehouse"
-    printf "    With --remove, remove the global lakehouse credential\n"
-    printf "    %s\n" "Needs: --remove"
-    echo
-
-    # :flag.usage
-    printf "  %s\n" "--all"
-    printf "    With --remove, remove all stored credentials and config\n"
-    printf "    %s\n" "Needs: --remove"
+    printf "    Remove the stored credential\n"
     echo
 
     # :flag.usage
@@ -487,7 +444,7 @@ altertable_configure_usage() {
     printf "  altertable configure --user u_blabla --password s_llll\n"
     printf "  altertable configure --api-key atm_xxxx --env production\n"
     printf "  altertable configure --list\n"
-    printf "  altertable configure --remove --env production\n"
+    printf "  altertable configure --remove\n"
     echo
 
   fi
@@ -647,93 +604,81 @@ config_get() { kv_get "$(config_file)" "$1"; }
 config_set() { local f; f="$(config_file)"; kv_set "$f" "$1" "$2"; chmod 600 "$f" 2>/dev/null || true; }
 config_unset() { kv_unset "$(config_file)" "$1"; }
 
-# The comma-separated "environments" list (one env per line on output).
-config_envs() {
-  local raw; raw="$(config_get environments)"
-  [[ -z "$raw" ]] && return 0
-  printf '%s\n' "$raw" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' || true
-}
-config_env_exists() {
-  local target="$1" e
-  while IFS= read -r e; do [[ "$e" == "$target" ]] && return 0; done < <(config_envs)
-  return 1
-}
-config_add_env() {
-  local env="$1" joined
-  config_env_exists "$env" && return 0
-  joined="$( { config_envs; printf '%s\n' "$env"; } | grep -v '^$' | paste -sd, - || true)"
-  config_set environments "$joined"
-}
-config_remove_env_from_list() {
-  local env="$1" joined
-  joined="$(config_envs | grep -vx "$env" | paste -sd, - || true)"
-  if [[ -z "$joined" ]]; then config_unset environments; else config_set environments "$joined"; fi
-}
-
-resolve_api_base() {
-  if [[ -n "${ALTERTABLE_API_BASE:-}" ]]; then echo "${ALTERTABLE_API_BASE}"; return 0; fi
-  local c; c="$(config_get api_base)"
-  if [[ -n "$c" ]]; then echo "$c"; return 0; fi
-  echo "https://api.altertable.ai"
-}
-resolve_app_base() {
-  if [[ -n "${ALTERTABLE_APP_BASE:-}" ]]; then echo "${ALTERTABLE_APP_BASE}"; return 0; fi
-  local c; c="$(config_get app_base)"
-  if [[ -n "$c" ]]; then echo "$c"; return 0; fi
-  echo "https://app.altertable.ai"
-}
+resolve_api_base() { echo "${ALTERTABLE_API_BASE:-https://api.altertable.ai}"; }
 
 # src/lib/configure.sh
 # Operations behind `altertable configure`. These read the global `args` array
-# (set by bashly), consistent with the other libraries.
+# (set by bashly), consistent with the other libraries. A new `configure` always
+# REPLACES any previously stored credential — mechanisms are never combined.
+
+# Remove every stored credential and auth identity.
+configure_clear_all() {
+  secret_delete "lakehouse/password"
+  secret_delete "lakehouse/basic-token"
+  secret_delete "api-key"
+  config_unset user
+  config_unset api_key_env
+}
 
 configure_run_set() {
   local user="${args[--user]:-}"
   local password="${args[--password]:-}"
   local basic_token="${args[--basic-token]:-}"
   local api_key="${args[--api-key]:-}"
-  local api_base="${args[--api-base]:-}"
-  local app_base="${args[--app-base]:-}"
   local env="${args[--env]:-}"
+  local want_pw_stdin="${args[--password-stdin]:-}"
+  local want_key_stdin="${args[--api-key-stdin]:-}"
 
-  # Read secrets from stdin when requested (mutual exclusion is enforced by bashly).
-  if [[ -n "${args[--password-stdin]:-}" ]]; then IFS= read -r password || true; fi
-  if [[ -n "${args[--api-key-stdin]:-}" ]]; then IFS= read -r api_key || true; fi
+  # No input at all -> interactive lakehouse setup.
+  if [[ -z "$user$password$basic_token$api_key$env$want_pw_stdin$want_key_stdin" ]]; then
+    configure_run_interactive
+    return 0
+  fi
 
-  # --env applies only to --api-key/--default; lakehouse credentials are global.
-  if [[ -n "$env" && -z "$api_key" && -z "${args[--api-key-stdin]:-}" && -z "${args[--default]:-}" ]]; then
-    log_error "--env applies only to --api-key/--default; lakehouse credentials are global."
+  if [[ -n "$want_pw_stdin" ]]; then IFS= read -r password || true; fi
+  if [[ -n "$want_key_stdin" ]]; then IFS= read -r api_key || true; fi
+
+  # Identify the requested mechanism; at most one is allowed.
+  local m_lakehouse="" m_token="" m_apikey="" count=0
+  [[ -n "$user" || -n "$password" ]] && m_lakehouse=1
+  [[ -n "$basic_token" ]] && m_token=1
+  [[ -n "$api_key" ]] && m_apikey=1
+  [[ -n "$m_lakehouse" ]] && count=$((count + 1))
+  [[ -n "$m_token" ]] && count=$((count + 1))
+  [[ -n "$m_apikey" ]] && count=$((count + 1))
+
+  if [[ "$count" -gt 1 ]]; then
+    log_error "Choose a single authentication mechanism: --user/--password, --basic-token, or --api-key (they cannot be combined)."
+    exit 1
+  fi
+  if [[ -n "$env" && -z "$m_apikey" ]]; then
+    log_error "--env applies only to --api-key."
+    exit 1
+  fi
+  if [[ "$count" -eq 0 ]]; then
+    log_error "Nothing to configure. Use --user/--password, --basic-token, or --api-key --env <name>."
+    exit 1
+  fi
+  if [[ -n "$m_lakehouse" && ( -z "$user" || -z "$password" ) ]]; then
+    log_error "--user and --password must be provided together."
+    exit 1
+  fi
+  if [[ -n "$m_apikey" && -z "$env" ]]; then
+    log_error "--api-key requires --env <name>."
     exit 1
   fi
 
-  # Interactive when nothing was provided.
-  if [[ -z "$user" && -z "$password" && -z "$basic_token" && -z "$api_key" \
-        && -z "$api_base" && -z "$app_base" && -z "$env" \
-        && -z "${args[--password-stdin]:-}" && -z "${args[--api-key-stdin]:-}" \
-        && -z "${args[--default]:-}" ]]; then
-    configure_run_interactive
-    return
+  # Override: a new configuration replaces any previous one.
+  configure_clear_all
+  if [[ -n "$m_apikey" ]]; then
+    secret_set "api-key" "$api_key"
+    config_set api_key_env "$env"
+  elif [[ -n "$m_token" ]]; then
+    secret_set "lakehouse/basic-token" "$basic_token"
+  else
+    config_set user "$user"
+    secret_set "lakehouse/password" "$password"
   fi
-
-  # Lakehouse credentials (global).
-  [[ -n "$user" ]] && config_set user "$user"
-  [[ -n "$password" ]] && secret_set "lakehouse/password" "$password"
-  [[ -n "$basic_token" ]] && secret_set "lakehouse/basic-token" "$basic_token"
-  [[ -n "$api_base" ]] && config_set api_base "$api_base"
-  [[ -n "$app_base" ]] && config_set app_base "$app_base"
-
-  # Management API key (per environment; --env is guaranteed present by bashly `needs`).
-  if [[ -n "$api_key" ]]; then
-    secret_set "apikey/${env}" "$api_key"
-    config_add_env "$env"
-    if [[ -z "$(config_get default_env)" || -n "${args[--default]:-}" ]]; then
-      config_set default_env "$env"
-    fi
-  elif [[ -n "${args[--default]:-}" ]]; then
-    config_env_exists "$env" || { log_error "Unknown environment '${env}'. Configure an API key for it first."; exit 1; }
-    config_set default_env "$env"
-  fi
-
   printf 'Configuration updated.\n' >&2
 }
 
@@ -752,36 +697,40 @@ configure_run_interactive() {
   printf '\n' >&2
   [[ -z "$user" ]] && { log_error "Username is required."; exit 1; }
   [[ -z "$password" ]] && { log_error "Password is required."; exit 1; }
+  configure_clear_all
   config_set user "$user"
   secret_set "lakehouse/password" "$password"
   printf 'Saved lakehouse credentials for user %s.\n' "$user" >&2
 }
-configure_run_list() {
-  local user api_base app_base default_env e found=0
-  user="$(config_get user)"
-  api_base="$(resolve_api_base)"
-  app_base="$(resolve_app_base)"
-  default_env="$(config_get default_env)"
 
+configure_run_list() {
+  local store_display
+  case "$(secret_backend)" in
+    macos) store_display="MacOS keychain" ;;
+    *)     store_display="$(credentials_file)" ;;
+  esac
   printf 'Altertable CLI configuration\n'
   printf '  Config dir:    %s\n' "$(config_dir)"
-  printf '  Secret store:  %s\n' "$(secret_backend)"
-  printf '\n  Lakehouse (data plane):\n'
-  printf '    user:        %s\n' "${user:-(not set)}"
-  if secret_exists "lakehouse/password"; then printf '    password:    set\n'; else printf '    password:    (not set)\n'; fi
-  if secret_exists "lakehouse/basic-token"; then printf '    basic-token: set\n'; fi
-  printf '    api_base:    %s\n' "$api_base"
-  printf '\n  Management API keys (by environment):\n'
-  printf '    app_base:    %s\n' "$app_base"
-  printf '    default env: %s\n' "${default_env:-(none)}"
-  while IFS= read -r e; do
-    [[ -z "$e" ]] && continue
-    found=1
-    if secret_exists "apikey/${e}"; then printf '    %s: set\n' "$e"; else printf '    %s: (listed, no key)\n' "$e"; fi
-  done < <(config_envs)
-  [[ "$found" -eq 0 ]] && printf '    (none configured)\n'
+  printf '  Secret store:  %s\n' "$store_display"
+  printf '  Data plane:    %s\n' "$(resolve_api_base)"
+  printf '\n'
+  if secret_exists "api-key"; then
+    printf '  Authentication: management API key\n'
+    printf '    environment:  %s\n' "$(config_get api_key_env)"
+    printf '    api key:      set\n'
+  elif secret_exists "lakehouse/basic-token"; then
+    printf '  Authentication: lakehouse Basic token\n'
+    printf '    basic token:  set\n'
+  elif secret_exists "lakehouse/password"; then
+    printf '  Authentication: lakehouse username/password\n'
+    printf '    user:         %s\n' "$(config_get user)"
+    printf '    password:     set\n'
+  else
+    printf '  No credentials configured. Run: altertable configure\n'
+  fi
   return 0
 }
+
 _confirm() {
   local msg="$1" ans
   [[ -n "${args[--yes]:-}" ]] && return 0
@@ -791,34 +740,10 @@ _confirm() {
 }
 
 configure_run_remove() {
-  local env="${args[--env]:-}" e
-  if [[ -n "${args[--all]:-}" ]]; then
-    _confirm "Remove ALL altertable credentials and configuration?" || { printf 'Aborted.\n' >&2; return; }
-    while IFS= read -r e; do [[ -n "$e" ]] && secret_delete "apikey/${e}"; done < <(config_envs)
-    secret_delete "lakehouse/password"
-    secret_delete "lakehouse/basic-token"
-    rm -f "$(config_file)" "$(credentials_file)"
-    printf 'Removed all altertable credentials and configuration.\n' >&2
-    return
-  fi
-  if [[ -n "${args[--lakehouse]:-}" ]]; then
-    _confirm "Remove the global lakehouse credential?" || { printf 'Aborted.\n' >&2; return; }
-    secret_delete "lakehouse/password"
-    secret_delete "lakehouse/basic-token"
-    config_unset user
-    printf 'Removed lakehouse credential.\n' >&2
-    return
-  fi
-  if [[ -z "$env" ]]; then
-    log_error "Specify what to remove: --env <name>, --lakehouse, or --all."
-    exit 1
-  fi
-  config_env_exists "$env" || { log_error "No configuration for environment '${env}'."; exit 1; }
-  _confirm "Remove API key for environment '${env}'?" || { printf 'Aborted.\n' >&2; return; }
-  secret_delete "apikey/${env}"
-  config_remove_env_from_list "$env"
-  [[ "$(config_get default_env)" == "$env" ]] && config_unset default_env
-  printf "Removed API key for environment '%s'.\n" "$env" >&2
+  _confirm "Remove the stored altertable credential?" || { printf 'Aborted.\n' >&2; return 0; }
+  configure_clear_all
+  printf 'Removed stored credential.\n' >&2
+  return 0
 }
 
 # src/lib/encode.sh
@@ -928,12 +853,28 @@ log_warn() {
 }
 
 # src/lib/secret.sh
-# Secret storage: OS keychain when available, else a 0600 fallback file.
-# Accounts: lakehouse/password, lakehouse/basic-token, apikey/<env>. Service: "altertable".
+# Secret storage: macOS Keychain when available, otherwise a 0600 file.
+# Accounts: lakehouse/password, lakehouse/basic-token, api-key. Service: "altertable".
+# We refuse to read the fallback file if its permissions are looser than 600.
+
+_file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+
+# Refuse to read the credentials file when group/other have any access.
+_require_safe_credentials_file() {
+  local f mode
+  f="$(credentials_file)"
+  [[ -f "$f" ]] || return 0
+  mode="$(_file_mode "$f")"
+  [[ -n "$mode" ]] || return 0
+  if (( (8#$mode) & 8#077 )); then
+    log_error "Refusing to read ${f}: permissions ${mode} are too open (group/other access). Run: chmod 600 ${f}"
+    exit 1
+  fi
+}
 
 _warn_file_backend_once() {
   if [[ -z "${_FILE_BACKEND_WARNED:-}" ]]; then
-    log_warn "No OS keychain found; storing secrets at $(credentials_file) (chmod 600). Prefer environment variables in CI."
+    log_warn "No macOS keychain; storing secrets at $(credentials_file) (chmod 600). Prefer environment variables in CI."
     _FILE_BACKEND_WARNED=1
   fi
 }
@@ -942,17 +883,19 @@ secret_backend() {
   local override="${ALTERTABLE_SECRET_BACKEND:-}"
   case "$override" in
     file) echo "file"; return 0 ;;
+    keychain)
+      if [[ "$(uname)" == "Darwin" ]] && command -v security >/dev/null 2>&1; then
+        echo "macos"; return 0
+      fi
+      log_error "ALTERTABLE_SECRET_BACKEND=keychain but the macOS keychain is unavailable."
+      exit 1
+      ;;
   esac
   if [[ "$(uname)" == "Darwin" ]] && command -v security >/dev/null 2>&1; then
-    echo "macos"; return 0
-  elif command -v secret-tool >/dev/null 2>&1; then
-    echo "linux"; return 0
+    echo "macos"
+  else
+    echo "file"
   fi
-  if [[ "$override" == "keychain" ]]; then
-    log_error "ALTERTABLE_SECRET_BACKEND=keychain but no OS keychain tool was found."
-    exit 1
-  fi
-  echo "file"
 }
 
 secret_set() {
@@ -960,8 +903,6 @@ secret_set() {
   case "$(secret_backend)" in
     macos) security add-generic-password -U -s "altertable" -a "$account" -w "$value" >/dev/null 2>&1 \
              || { log_error "Failed to store secret in macOS keychain ($account)."; exit 1; } ;;
-    linux) printf '%s' "$value" | secret-tool store --label="altertable $account" service "altertable" account "$account" \
-             || { log_error "Failed to store secret via secret-tool ($account)."; exit 1; } ;;
     file)
       f="$(credentials_file)"
       kv_set "$f" "$account" "$value"
@@ -975,8 +916,7 @@ secret_get() {
   local account="$1" val=""
   case "$(secret_backend)" in
     macos) val="$(security find-generic-password -s "altertable" -a "$account" -w 2>/dev/null || true)" ;;
-    linux) val="$(secret-tool lookup service "altertable" account "$account" 2>/dev/null || true)" ;;
-    file)  val="$(kv_get "$(credentials_file)" "$account")" ;;
+    file)  _require_safe_credentials_file; val="$(kv_get "$(credentials_file)" "$account")" ;;
   esac
   printf '%s' "$val"
 }
@@ -985,8 +925,7 @@ secret_exists() {
   local account="$1"
   case "$(secret_backend)" in
     macos) security find-generic-password -s "altertable" -a "$account" >/dev/null 2>&1 ;;
-    linux) secret-tool lookup service "altertable" account "$account" >/dev/null 2>&1 ;;
-    file)  [[ -n "$(kv_get "$(credentials_file)" "$account")" ]] ;;
+    file)  _require_safe_credentials_file; [[ -n "$(kv_get "$(credentials_file)" "$account")" ]] ;;
   esac
 }
 
@@ -994,7 +933,6 @@ secret_delete() {
   local account="$1"
   case "$(secret_backend)" in
     macos) security delete-generic-password -s "altertable" -a "$account" >/dev/null 2>&1 || true ;;
-    linux) secret-tool clear service "altertable" account "$account" >/dev/null 2>&1 || true ;;
     file)  kv_unset "$(credentials_file)" "$account" ;;
   esac
 }
@@ -1209,9 +1147,6 @@ parse_requirements() {
   env_var_names+=("ALTERTABLE_LAKEHOUSE_PASSWORD")
   env_var_names+=("ALTERTABLE_BASIC_AUTH_TOKEN")
   env_var_names+=("ALTERTABLE_API_BASE")
-  env_var_names+=("ALTERTABLE_APP_BASE")
-  env_var_names+=("ALTERTABLE_API_KEY")
-  env_var_names+=("ALTERTABLE_ENV")
   env_var_names+=("ALTERTABLE_CONFIG_HOME")
   env_var_names+=("ALTERTABLE_SECRET_BACKEND")
 
@@ -2103,42 +2038,6 @@ altertable_configure_parse_requirements() {
         ;;
 
       # :flag.case
-      --default)
-
-        # :flag.case_no_arg
-        args['--default']=1
-        shift
-        ;;
-
-      # :flag.case
-      --api-base)
-
-        # :flag.case_arg
-        if [[ -n ${2+x} ]]; then
-          args['--api-base']="$2"
-          shift
-          shift
-        else
-          printf "%s\n" "--api-base requires an argument: --api-base URL" >&2
-          exit 1
-        fi
-        ;;
-
-      # :flag.case
-      --app-base)
-
-        # :flag.case_arg
-        if [[ -n ${2+x} ]]; then
-          args['--app-base']="$2"
-          shift
-          shift
-        else
-          printf "%s\n" "--app-base requires an argument: --app-base URL" >&2
-          exit 1
-        fi
-        ;;
-
-      # :flag.case
       --list)
 
         # :flag.case_no_arg
@@ -2151,22 +2050,6 @@ altertable_configure_parse_requirements() {
 
         # :flag.case_no_arg
         args['--remove']=1
-        shift
-        ;;
-
-      # :flag.case
-      --lakehouse)
-
-        # :flag.case_no_arg
-        args['--lakehouse']=1
-        shift
-        ;;
-
-      # :flag.case
-      --all)
-
-        # :flag.case_no_arg
-        args['--all']=1
         shift
         ;;
 
@@ -2212,24 +2095,6 @@ altertable_configure_parse_requirements() {
   # :flag.needs
   if [[ -n ${args['--api-key-stdin']+x} ]] && [[ -z "${args[--env]:-}" ]]; then
     printf "%s\n" "--api-key-stdin needs --env" >&2
-    exit 1
-  fi
-
-  # :flag.needs
-  if [[ -n ${args['--default']+x} ]] && [[ -z "${args[--env]:-}" ]]; then
-    printf "%s\n" "--default needs --env" >&2
-    exit 1
-  fi
-
-  # :flag.needs
-  if [[ -n ${args['--lakehouse']+x} ]] && [[ -z "${args[--remove]:-}" ]]; then
-    printf "%s\n" "--lakehouse needs --remove" >&2
-    exit 1
-  fi
-
-  # :flag.needs
-  if [[ -n ${args['--all']+x} ]] && [[ -z "${args[--remove]:-}" ]]; then
-    printf "%s\n" "--all needs --remove" >&2
     exit 1
   fi
 

--- a/bin/altertable
+++ b/bin/altertable
@@ -32,6 +32,7 @@ altertable_usage() {
   printf "  %s   Upload a file to create or update a table.\n" "upload   "
   printf "  %s   Fetch metadata for a completed or running query.\n" "get-query"
   printf "  %s   Cancel a running query.\n" "cancel   "
+  printf "  %s   Configure and securely store credentials and settings.\n" "configure"
   echo
 
   # :command.long_usage
@@ -73,7 +74,32 @@ altertable_usage() {
 
     # :environment_variable.usage
     printf "  %s\n" "ALTERTABLE_API_BASE"
-    printf "    API Base URL (default: https://api.altertable.ai)\n"
+    printf "    Data plane API Base URL (default: https://api.altertable.ai)\n"
+    echo
+
+    # :environment_variable.usage
+    printf "  %s\n" "ALTERTABLE_APP_BASE"
+    printf "    Management API Base URL (default: https://app.altertable.ai)\n"
+    echo
+
+    # :environment_variable.usage
+    printf "  %s\n" "ALTERTABLE_API_KEY"
+    printf "    Management API key (overrides stored value)\n"
+    echo
+
+    # :environment_variable.usage
+    printf "  %s\n" "ALTERTABLE_ENV"
+    printf "    Default environment for management operations\n"
+    echo
+
+    # :environment_variable.usage
+    printf "  %s\n" "ALTERTABLE_CONFIG_HOME"
+    printf "    Config/credentials directory (default: $XDG_CONFIG_HOME/altertable)\n"
+    echo
+
+    # :environment_variable.usage
+    printf "  %s\n" "ALTERTABLE_SECRET_BACKEND"
+    printf "    Force secret storage backend: keychain | file (default: auto-detect)\n"
     echo
 
   fi
@@ -346,6 +372,127 @@ altertable_cancel_usage() {
   fi
 }
 
+# :command.usage
+altertable_configure_usage() {
+  printf "altertable configure - Configure and securely store credentials and settings.\n\n"
+
+  printf "%s\n" "Usage:"
+  printf "  altertable configure [OPTIONS]\n"
+  printf "  altertable configure --help | -h\n"
+  echo
+
+  # :command.long_usage
+  if [[ -n "$long_usage" ]]; then
+    # :command.usage_options
+    printf "%s\n" "Options:"
+
+    # :command.usage_flags
+    # :flag.usage
+    printf "  %s\n" "--user USERNAME"
+    printf "    Lakehouse username (global)\n"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--password PASSWORD"
+    printf "    Lakehouse password (global)\n"
+    printf "    %s\n" "Conflicts: --password-stdin"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--password-stdin"
+    printf "    Read the lakehouse password from stdin\n"
+    printf "    %s\n" "Conflicts: --password, --api-key-stdin"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--basic-token TOKEN"
+    printf "    Pre-encoded HTTP Basic token (alternative to user/password)\n"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--api-key KEY"
+    printf "    Management API key for the --env environment\n"
+    printf "    %s\n" "Needs: --env"
+    printf "    %s\n" "Conflicts: --api-key-stdin"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--api-key-stdin"
+    printf "    Read the management API key from stdin\n"
+    printf "    %s\n" "Needs: --env"
+    printf "    %s\n" "Conflicts: --api-key, --password-stdin"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--env NAME"
+    printf "    Target environment (management API keys are per-environment)\n"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--default"
+    printf "    Mark the --env environment as the default\n"
+    printf "    %s\n" "Needs: --env"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--api-base URL"
+    printf "    Override the data-plane base URL\n"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--app-base URL"
+    printf "    Override the management base URL\n"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--list"
+    printf "    Show stored configuration (secrets masked)\n"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--remove"
+    printf "    Remove stored credentials (with --env, --lakehouse, or --all)\n"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--lakehouse"
+    printf "    With --remove, remove the global lakehouse credential\n"
+    printf "    %s\n" "Needs: --remove"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--all"
+    printf "    With --remove, remove all stored credentials and config\n"
+    printf "    %s\n" "Needs: --remove"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--yes, -y"
+    printf "    Do not prompt for confirmation\n"
+    echo
+
+    # :flag.usage
+    printf "  %s\n" "--debug"
+    printf "    Enable debug output\n"
+    echo
+
+    # :command.usage_fixed_flags
+    printf "  %s\n" "--help, -h"
+    printf "    Show this help\n"
+    echo
+
+    # :command.usage_examples
+    printf "%s\n" "Examples:"
+    printf "  altertable configure\n"
+    printf "  altertable configure --user u_blabla --password s_llll\n"
+    printf "  altertable configure --api-key atm_xxxx --env production\n"
+    printf "  altertable configure --list\n"
+    printf "  altertable configure --remove --env production\n"
+    echo
+
+  fi
+}
+
 # :command.normalize_input
 # :command.normalize_input_function
 normalize_input() {
@@ -425,6 +572,143 @@ get_auth_header() {
     exit 1
   fi
 }
+
+# src/lib/config.sh
+# Non-secret configuration: a flat "key=value" file plus base-URL resolution.
+
+trim() { printf '%s' "$1" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'; }
+
+config_dir() { echo "${ALTERTABLE_CONFIG_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/altertable}"; }
+config_file() { echo "$(config_dir)/config"; }
+credentials_file() { echo "$(config_dir)/credentials"; }
+
+# Flat "key=value" helpers (tolerant of surrounding whitespace, comments preserved).
+kv_get() {
+  local file="$1" key="$2" line k
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    k="$(trim "${line%%=*}")"
+    if [[ "$k" == "$key" ]]; then
+      trim "${line#*=}"
+      printf '\n'
+      return 0
+    fi
+  done < "$file"
+  return 0
+}
+
+kv_set() {
+  local file="$1" key="$2" value="$3" tmp line k found=0
+  mkdir -p "$(dirname "$file")"
+  tmp="$(mktemp)"
+  if [[ -f "$file" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      k="$(trim "${line%%=*}")"
+      if [[ "$k" == "$key" ]]; then
+        printf '%s=%s\n' "$key" "$value" >> "$tmp"
+        found=1
+      else
+        printf '%s\n' "$line" >> "$tmp"
+      fi
+    done < "$file"
+  fi
+  [[ "$found" -eq 0 ]] && printf '%s=%s\n' "$key" "$value" >> "$tmp"
+  mv "$tmp" "$file"
+}
+
+kv_unset() {
+  local file="$1" key="$2" tmp line k
+  [[ -f "$file" ]] || return 0
+  tmp="$(mktemp)"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    k="$(trim "${line%%=*}")"
+    [[ "$k" == "$key" ]] && continue
+    printf '%s\n' "$line" >> "$tmp"
+  done < "$file"
+  mv "$tmp" "$file"
+}
+
+config_get() { kv_get "$(config_file)" "$1"; }
+config_set() { local f; f="$(config_file)"; kv_set "$f" "$1" "$2"; chmod 600 "$f" 2>/dev/null || true; }
+config_unset() { kv_unset "$(config_file)" "$1"; }
+
+# The comma-separated "environments" list (one env per line on output).
+config_envs() {
+  local raw; raw="$(config_get environments)"
+  [[ -z "$raw" ]] && return 0
+  printf '%s\n' "$raw" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' || true
+}
+config_env_exists() {
+  local target="$1" e
+  while IFS= read -r e; do [[ "$e" == "$target" ]] && return 0; done < <(config_envs)
+  return 1
+}
+config_add_env() {
+  local env="$1" joined
+  config_env_exists "$env" && return 0
+  joined="$( { config_envs; printf '%s\n' "$env"; } | grep -v '^$' | paste -sd, - || true)"
+  config_set environments "$joined"
+}
+config_remove_env_from_list() {
+  local env="$1" joined
+  joined="$(config_envs | grep -vx "$env" | paste -sd, - || true)"
+  if [[ -z "$joined" ]]; then config_unset environments; else config_set environments "$joined"; fi
+}
+
+resolve_api_base() {
+  if [[ -n "${ALTERTABLE_API_BASE:-}" ]]; then echo "${ALTERTABLE_API_BASE}"; return 0; fi
+  local c; c="$(config_get api_base)"
+  if [[ -n "$c" ]]; then echo "$c"; return 0; fi
+  echo "https://api.altertable.ai"
+}
+resolve_app_base() {
+  if [[ -n "${ALTERTABLE_APP_BASE:-}" ]]; then echo "${ALTERTABLE_APP_BASE}"; return 0; fi
+  local c; c="$(config_get app_base)"
+  if [[ -n "$c" ]]; then echo "$c"; return 0; fi
+  echo "https://app.altertable.ai"
+}
+
+# src/lib/configure.sh
+# Operations behind `altertable configure`. These read the global `args` array
+# (set by bashly), consistent with the other libraries.
+
+configure_run_set() {
+  local user="${args[--user]:-}"
+  local password="${args[--password]:-}"
+  local basic_token="${args[--basic-token]:-}"
+  local api_key="${args[--api-key]:-}"
+  local api_base="${args[--api-base]:-}"
+  local app_base="${args[--app-base]:-}"
+  local env="${args[--env]:-}"
+
+  # === stdin + --env validation: see Task 3 ===
+
+  # Interactive when nothing was provided.
+  if [[ -z "$user" && -z "$password" && -z "$basic_token" && -z "$api_key" \
+        && -z "$api_base" && -z "$app_base" && -z "$env" \
+        && -z "${args[--password-stdin]:-}" && -z "${args[--api-key-stdin]:-}" \
+        && -z "${args[--default]:-}" ]]; then
+    configure_run_interactive
+    return
+  fi
+
+  # Lakehouse credentials (global).
+  [[ -n "$user" ]] && config_set user "$user"
+  [[ -n "$password" ]] && secret_set "lakehouse/password" "$password"
+  [[ -n "$basic_token" ]] && secret_set "lakehouse/basic-token" "$basic_token"
+  [[ -n "$api_base" ]] && config_set api_base "$api_base"
+  [[ -n "$app_base" ]] && config_set app_base "$app_base"
+
+  # === management API key: see Task 2 ===
+
+  printf 'Configuration updated.\n' >&2
+}
+
+# Stubs replaced in later tasks.
+configure_run_interactive() { log_error "interactive configure not yet available"; exit 1; }
+configure_run_list() { log_error "configure --list not yet available"; exit 1; }
+configure_run_remove() { log_error "configure --remove not yet available"; exit 1; }
 
 # src/lib/encode.sh
 urlencode() {
@@ -526,6 +810,82 @@ log_debug() {
 
 log_error() {
   echo "[ERROR] $1" >&2
+}
+
+log_warn() {
+  echo "[WARN] $1" >&2
+}
+
+# src/lib/secret.sh
+# Secret storage: OS keychain when available, else a 0600 fallback file.
+# Accounts: lakehouse/password, lakehouse/basic-token, apikey/<env>. Service: "altertable".
+
+_warn_file_backend_once() {
+  if [[ -z "${_FILE_BACKEND_WARNED:-}" ]]; then
+    log_warn "No OS keychain found; storing secrets at $(credentials_file) (chmod 600). Prefer environment variables in CI."
+    _FILE_BACKEND_WARNED=1
+  fi
+}
+
+secret_backend() {
+  local override="${ALTERTABLE_SECRET_BACKEND:-}"
+  case "$override" in
+    file) echo "file"; return 0 ;;
+  esac
+  if [[ "$(uname)" == "Darwin" ]] && command -v security >/dev/null 2>&1; then
+    echo "macos"; return 0
+  elif command -v secret-tool >/dev/null 2>&1; then
+    echo "linux"; return 0
+  fi
+  if [[ "$override" == "keychain" ]]; then
+    log_error "ALTERTABLE_SECRET_BACKEND=keychain but no OS keychain tool was found."
+    exit 1
+  fi
+  echo "file"
+}
+
+secret_set() {
+  local account="$1" value="$2" f
+  case "$(secret_backend)" in
+    macos) security add-generic-password -U -s "altertable" -a "$account" -w "$value" >/dev/null 2>&1 \
+             || { log_error "Failed to store secret in macOS keychain ($account)."; exit 1; } ;;
+    linux) printf '%s' "$value" | secret-tool store --label="altertable $account" service "altertable" account "$account" \
+             || { log_error "Failed to store secret via secret-tool ($account)."; exit 1; } ;;
+    file)
+      f="$(credentials_file)"
+      kv_set "$f" "$account" "$value"
+      chmod 600 "$f"
+      _warn_file_backend_once
+      ;;
+  esac
+}
+
+secret_get() {
+  local account="$1" val=""
+  case "$(secret_backend)" in
+    macos) val="$(security find-generic-password -s "altertable" -a "$account" -w 2>/dev/null || true)" ;;
+    linux) val="$(secret-tool lookup service "altertable" account "$account" 2>/dev/null || true)" ;;
+    file)  val="$(kv_get "$(credentials_file)" "$account")" ;;
+  esac
+  printf '%s' "$val"
+}
+
+secret_exists() {
+  local account="$1"
+  case "$(secret_backend)" in
+    macos) security find-generic-password -s "altertable" -a "$account" >/dev/null 2>&1 ;;
+    linux) secret-tool lookup service "altertable" account "$account" >/dev/null 2>&1 ;;
+    file)  [[ -n "$(kv_get "$(credentials_file)" "$account")" ]] ;;
+  esac
+}
+
+secret_delete() {
+  local account="$1"
+  case "$(secret_backend)" in
+    macos) security delete-generic-password -s "altertable" -a "$account" >/dev/null 2>&1 || true ;;
+    linux) secret-tool clear service "altertable" account "$account" >/dev/null 2>&1 || true ;;
+    file)  kv_unset "$(credentials_file)" "$account" ;;
+  esac
 }
 
 # :command.command_functions
@@ -683,6 +1043,21 @@ altertable_cancel_command() {
 
 }
 
+# :command.function
+altertable_configure_command() {
+
+  # src/configure_command.sh
+  # Dispatch configure modes. Behavior lives in src/lib/configure.sh.
+  if [[ -n "${args[--list]:-}" ]]; then
+    configure_run_list
+  elif [[ -n "${args[--remove]:-}" ]]; then
+    configure_run_remove
+  else
+    configure_run_set
+  fi
+
+}
+
 # :command.parse_requirements
 parse_requirements() {
   local key
@@ -723,6 +1098,11 @@ parse_requirements() {
   env_var_names+=("ALTERTABLE_LAKEHOUSE_PASSWORD")
   env_var_names+=("ALTERTABLE_BASIC_AUTH_TOKEN")
   env_var_names+=("ALTERTABLE_API_BASE")
+  env_var_names+=("ALTERTABLE_APP_BASE")
+  env_var_names+=("ALTERTABLE_API_KEY")
+  env_var_names+=("ALTERTABLE_ENV")
+  env_var_names+=("ALTERTABLE_CONFIG_HOME")
+  env_var_names+=("ALTERTABLE_SECRET_BACKEND")
 
   # :command.command_filter
   action=${1:-}
@@ -769,6 +1149,13 @@ parse_requirements() {
       action="cancel"
       shift
       altertable_cancel_parse_requirements "$@"
+      shift $#
+      ;;
+
+    configure)
+      action="configure"
+      shift
+      altertable_configure_parse_requirements "$@"
       shift $#
       ;;
 
@@ -1466,6 +1853,277 @@ altertable_cancel_parse_requirements() {
 
 }
 
+# :command.parse_requirements
+altertable_configure_parse_requirements() {
+  local key
+
+  # :command.fixed_flags_filter
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+    case "$key" in
+      --help | -h)
+        long_usage=yes
+        altertable_configure_usage
+        exit
+        ;;
+
+      *)
+        break
+        ;;
+
+    esac
+  done
+
+  # :command.command_filter
+  action="configure"
+
+  # :command.parse_requirements_while
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+    case "$key" in
+      # :flag.case
+      --user)
+
+        # :flag.case_arg
+        if [[ -n ${2+x} ]]; then
+          args['--user']="$2"
+          shift
+          shift
+        else
+          printf "%s\n" "--user requires an argument: --user USERNAME" >&2
+          exit 1
+        fi
+        ;;
+
+      # :flag.case
+      --password)
+        # :flag.conflicts
+        if [[ -n "${args['--password-stdin']:-}" ]]; then
+          printf "conflicting options: %s cannot be used with %s\n" "$key" "--password-stdin" >&2
+          exit 1
+        fi
+
+        # :flag.case_arg
+        if [[ -n ${2+x} ]]; then
+          args['--password']="$2"
+          shift
+          shift
+        else
+          printf "%s\n" "--password requires an argument: --password PASSWORD" >&2
+          exit 1
+        fi
+        ;;
+
+      # :flag.case
+      --password-stdin)
+        # :flag.conflicts
+        for conflict in --password --api-key-stdin; do
+          if [[ -n "${args[$conflict]:-}" ]]; then
+            printf "conflicting options: %s cannot be used with %s\n" "$key" "$conflict" >&2
+            exit 1
+          fi
+        done
+
+        # :flag.case_no_arg
+        args['--password-stdin']=1
+        shift
+        ;;
+
+      # :flag.case
+      --basic-token)
+
+        # :flag.case_arg
+        if [[ -n ${2+x} ]]; then
+          args['--basic-token']="$2"
+          shift
+          shift
+        else
+          printf "%s\n" "--basic-token requires an argument: --basic-token TOKEN" >&2
+          exit 1
+        fi
+        ;;
+
+      # :flag.case
+      --api-key)
+        # :flag.conflicts
+        if [[ -n "${args['--api-key-stdin']:-}" ]]; then
+          printf "conflicting options: %s cannot be used with %s\n" "$key" "--api-key-stdin" >&2
+          exit 1
+        fi
+
+        # :flag.case_arg
+        if [[ -n ${2+x} ]]; then
+          args['--api-key']="$2"
+          shift
+          shift
+        else
+          printf "%s\n" "--api-key requires an argument: --api-key KEY" >&2
+          exit 1
+        fi
+        ;;
+
+      # :flag.case
+      --api-key-stdin)
+        # :flag.conflicts
+        for conflict in --api-key --password-stdin; do
+          if [[ -n "${args[$conflict]:-}" ]]; then
+            printf "conflicting options: %s cannot be used with %s\n" "$key" "$conflict" >&2
+            exit 1
+          fi
+        done
+
+        # :flag.case_no_arg
+        args['--api-key-stdin']=1
+        shift
+        ;;
+
+      # :flag.case
+      --env)
+
+        # :flag.case_arg
+        if [[ -n ${2+x} ]]; then
+          args['--env']="$2"
+          shift
+          shift
+        else
+          printf "%s\n" "--env requires an argument: --env NAME" >&2
+          exit 1
+        fi
+        ;;
+
+      # :flag.case
+      --default)
+
+        # :flag.case_no_arg
+        args['--default']=1
+        shift
+        ;;
+
+      # :flag.case
+      --api-base)
+
+        # :flag.case_arg
+        if [[ -n ${2+x} ]]; then
+          args['--api-base']="$2"
+          shift
+          shift
+        else
+          printf "%s\n" "--api-base requires an argument: --api-base URL" >&2
+          exit 1
+        fi
+        ;;
+
+      # :flag.case
+      --app-base)
+
+        # :flag.case_arg
+        if [[ -n ${2+x} ]]; then
+          args['--app-base']="$2"
+          shift
+          shift
+        else
+          printf "%s\n" "--app-base requires an argument: --app-base URL" >&2
+          exit 1
+        fi
+        ;;
+
+      # :flag.case
+      --list)
+
+        # :flag.case_no_arg
+        args['--list']=1
+        shift
+        ;;
+
+      # :flag.case
+      --remove)
+
+        # :flag.case_no_arg
+        args['--remove']=1
+        shift
+        ;;
+
+      # :flag.case
+      --lakehouse)
+
+        # :flag.case_no_arg
+        args['--lakehouse']=1
+        shift
+        ;;
+
+      # :flag.case
+      --all)
+
+        # :flag.case_no_arg
+        args['--all']=1
+        shift
+        ;;
+
+      # :flag.case
+      --yes | -y)
+
+        # :flag.case_no_arg
+        args['--yes']=1
+        shift
+        ;;
+
+      # :flag.case
+      --debug)
+
+        # :flag.case_no_arg
+        args['--debug']=1
+        shift
+        ;;
+
+      -?*)
+        printf "invalid option: %s\n" "$key" >&2
+        exit 1
+        ;;
+
+      *)
+        # :command.parse_requirements_case
+        # :command.parse_requirements_case_simple
+        printf "invalid argument: %s\n" "$key" >&2
+        exit 1
+
+        ;;
+
+    esac
+  done
+
+  # :command.needy_flags_filter
+  # :flag.needs
+  if [[ -n ${args['--api-key']+x} ]] && [[ -z "${args[--env]:-}" ]]; then
+    printf "%s\n" "--api-key needs --env" >&2
+    exit 1
+  fi
+
+  # :flag.needs
+  if [[ -n ${args['--api-key-stdin']+x} ]] && [[ -z "${args[--env]:-}" ]]; then
+    printf "%s\n" "--api-key-stdin needs --env" >&2
+    exit 1
+  fi
+
+  # :flag.needs
+  if [[ -n ${args['--default']+x} ]] && [[ -z "${args[--env]:-}" ]]; then
+    printf "%s\n" "--default needs --env" >&2
+    exit 1
+  fi
+
+  # :flag.needs
+  if [[ -n ${args['--lakehouse']+x} ]] && [[ -z "${args[--remove]:-}" ]]; then
+    printf "%s\n" "--lakehouse needs --remove" >&2
+    exit 1
+  fi
+
+  # :flag.needs
+  if [[ -n ${args['--all']+x} ]] && [[ -z "${args[--remove]:-}" ]]; then
+    printf "%s\n" "--all needs --remove" >&2
+    exit 1
+  fi
+
+}
+
 # :command.initialize
 initialize() {
   declare -g version="0.4.0"
@@ -1492,6 +2150,7 @@ run() {
     "upload") altertable_upload_command ;;
     "get-query") altertable_get_query_command ;;
     "cancel") altertable_cancel_command ;;
+    "configure") altertable_configure_command ;;
   esac
 }
 

--- a/bin/altertable
+++ b/bin/altertable
@@ -700,7 +700,17 @@ configure_run_set() {
   [[ -n "$api_base" ]] && config_set api_base "$api_base"
   [[ -n "$app_base" ]] && config_set app_base "$app_base"
 
-  # === management API key: see Task 2 ===
+  # Management API key (per environment; --env is guaranteed present by bashly `needs`).
+  if [[ -n "$api_key" ]]; then
+    secret_set "apikey/${env}" "$api_key"
+    config_add_env "$env"
+    if [[ -z "$(config_get default_env)" || -n "${args[--default]:-}" ]]; then
+      config_set default_env "$env"
+    fi
+  elif [[ -n "${args[--default]:-}" ]]; then
+    config_env_exists "$env" || { log_error "Unknown environment '${env}'. Configure an API key for it first."; exit 1; }
+    config_set default_env "$env"
+  fi
 
   printf 'Configuration updated.\n' >&2
 }

--- a/bin/altertable
+++ b/bin/altertable
@@ -682,7 +682,15 @@ configure_run_set() {
   local app_base="${args[--app-base]:-}"
   local env="${args[--env]:-}"
 
-  # === stdin + --env validation: see Task 3 ===
+  # Read secrets from stdin when requested (mutual exclusion is enforced by bashly).
+  if [[ -n "${args[--password-stdin]:-}" ]]; then IFS= read -r password || true; fi
+  if [[ -n "${args[--api-key-stdin]:-}" ]]; then IFS= read -r api_key || true; fi
+
+  # --env applies only to --api-key/--default; lakehouse credentials are global.
+  if [[ -n "$env" && -z "$api_key" && -z "${args[--api-key-stdin]:-}" && -z "${args[--default]:-}" ]]; then
+    log_error "--env applies only to --api-key/--default; lakehouse credentials are global."
+    exit 1
+  fi
 
   # Interactive when nothing was provided.
   if [[ -z "$user" && -z "$password" && -z "$basic_token" && -z "$api_key" \

--- a/bin/altertable
+++ b/bin/altertable
@@ -725,7 +725,32 @@ configure_run_set() {
 
 # Stubs replaced in later tasks.
 configure_run_interactive() { log_error "interactive configure not yet available"; exit 1; }
-configure_run_list() { log_error "configure --list not yet available"; exit 1; }
+configure_run_list() {
+  local user api_base app_base default_env e found=0
+  user="$(config_get user)"
+  api_base="$(resolve_api_base)"
+  app_base="$(resolve_app_base)"
+  default_env="$(config_get default_env)"
+
+  printf 'Altertable CLI configuration\n'
+  printf '  Config dir:    %s\n' "$(config_dir)"
+  printf '  Secret store:  %s\n' "$(secret_backend)"
+  printf '\n  Lakehouse (data plane):\n'
+  printf '    user:        %s\n' "${user:-(not set)}"
+  if secret_exists "lakehouse/password"; then printf '    password:    set\n'; else printf '    password:    (not set)\n'; fi
+  if secret_exists "lakehouse/basic-token"; then printf '    basic-token: set\n'; fi
+  printf '    api_base:    %s\n' "$api_base"
+  printf '\n  Management API keys (by environment):\n'
+  printf '    app_base:    %s\n' "$app_base"
+  printf '    default env: %s\n' "${default_env:-(none)}"
+  while IFS= read -r e; do
+    [[ -z "$e" ]] && continue
+    found=1
+    if secret_exists "apikey/${e}"; then printf '    %s: set\n' "$e"; else printf '    %s: (listed, no key)\n' "$e"; fi
+  done < <(config_envs)
+  [[ "$found" -eq 0 ]] && printf '    (none configured)\n'
+  return 0
+}
 configure_run_remove() { log_error "configure --remove not yet available"; exit 1; }
 
 # src/lib/encode.sh

--- a/bin/altertable
+++ b/bin/altertable
@@ -751,7 +751,44 @@ configure_run_list() {
   [[ "$found" -eq 0 ]] && printf '    (none configured)\n'
   return 0
 }
-configure_run_remove() { log_error "configure --remove not yet available"; exit 1; }
+_confirm() {
+  local msg="$1" ans
+  [[ -n "${args[--yes]:-}" ]] && return 0
+  printf '%s [y/N] ' "$msg" >&2
+  IFS= read -r ans || true
+  [[ "$ans" == "y" || "$ans" == "Y" ]]
+}
+
+configure_run_remove() {
+  local env="${args[--env]:-}" e
+  if [[ -n "${args[--all]:-}" ]]; then
+    _confirm "Remove ALL altertable credentials and configuration?" || { printf 'Aborted.\n' >&2; return; }
+    while IFS= read -r e; do [[ -n "$e" ]] && secret_delete "apikey/${e}"; done < <(config_envs)
+    secret_delete "lakehouse/password"
+    secret_delete "lakehouse/basic-token"
+    rm -f "$(config_file)" "$(credentials_file)"
+    printf 'Removed all altertable credentials and configuration.\n' >&2
+    return
+  fi
+  if [[ -n "${args[--lakehouse]:-}" ]]; then
+    _confirm "Remove the global lakehouse credential?" || { printf 'Aborted.\n' >&2; return; }
+    secret_delete "lakehouse/password"
+    secret_delete "lakehouse/basic-token"
+    config_unset user
+    printf 'Removed lakehouse credential.\n' >&2
+    return
+  fi
+  if [[ -z "$env" ]]; then
+    log_error "Specify what to remove: --env <name>, --lakehouse, or --all."
+    exit 1
+  fi
+  config_env_exists "$env" || { log_error "No configuration for environment '${env}'."; exit 1; }
+  _confirm "Remove API key for environment '${env}'?" || { printf 'Aborted.\n' >&2; return; }
+  secret_delete "apikey/${env}"
+  config_remove_env_from_list "$env"
+  [[ "$(config_get default_env)" == "$env" ]] && config_unset default_env
+  printf "Removed API key for environment '%s'.\n" "$env" >&2
+}
 
 # src/lib/encode.sh
 urlencode() {

--- a/bin/altertable
+++ b/bin/altertable
@@ -737,7 +737,6 @@ configure_run_set() {
   printf 'Configuration updated.\n' >&2
 }
 
-# Stubs replaced in later tasks.
 configure_run_interactive() {
   local current_user user password
   current_user="$(config_get user)"

--- a/bin/altertable
+++ b/bin/altertable
@@ -561,16 +561,30 @@ inspect_args() {
 # :command.user_lib
 # src/lib/auth.sh
 get_auth_header() {
+  local token user pass
   if [[ -n "${ALTERTABLE_BASIC_AUTH_TOKEN:-}" ]]; then
     echo "Authorization: Basic ${ALTERTABLE_BASIC_AUTH_TOKEN}"
-  elif [[ -n "${ALTERTABLE_LAKEHOUSE_USERNAME:-}" && -n "${ALTERTABLE_LAKEHOUSE_PASSWORD:-}" ]]; then
-    local token
-    token=$(echo -n "${ALTERTABLE_LAKEHOUSE_USERNAME}:${ALTERTABLE_LAKEHOUSE_PASSWORD}" | base64 | tr -d '\n')
-    echo "Authorization: Basic ${token}"
-  else
-    log_error "Missing authentication. Set ALTERTABLE_LAKEHOUSE_USERNAME/PASSWORD or ALTERTABLE_BASIC_AUTH_TOKEN."
-    exit 1
+    return 0
   fi
+  if [[ -n "${ALTERTABLE_LAKEHOUSE_USERNAME:-}" && -n "${ALTERTABLE_LAKEHOUSE_PASSWORD:-}" ]]; then
+    token=$(printf '%s' "${ALTERTABLE_LAKEHOUSE_USERNAME}:${ALTERTABLE_LAKEHOUSE_PASSWORD}" | base64 | tr -d '\n')
+    echo "Authorization: Basic ${token}"
+    return 0
+  fi
+  token="$(secret_get 'lakehouse/basic-token')"
+  if [[ -n "$token" ]]; then
+    echo "Authorization: Basic ${token}"
+    return 0
+  fi
+  user="$(config_get user)"
+  pass="$(secret_get 'lakehouse/password')"
+  if [[ -n "$user" && -n "$pass" ]]; then
+    token=$(printf '%s' "${user}:${pass}" | base64 | tr -d '\n')
+    echo "Authorization: Basic ${token}"
+    return 0
+  fi
+  log_error "No credentials. Run 'altertable configure' or set ALTERTABLE_LAKEHOUSE_USERNAME/PASSWORD (or ALTERTABLE_BASIC_AUTH_TOKEN)."
+  exit 1
 }
 
 # src/lib/config.sh
@@ -827,7 +841,7 @@ http_request() {
   local data="$3"
   local extra_headers=("${@:4}")
 
-  local url="${ALTERTABLE_API_BASE:-https://api.altertable.ai}${endpoint}"
+  local url; url="$(resolve_api_base)${endpoint}"
   local user_agent="altertable-lakehouse-cli/${version}"
   local auth_header
   auth_header=$(get_auth_header)

--- a/bin/altertable
+++ b/bin/altertable
@@ -424,6 +424,11 @@ altertable_configure_usage() {
     echo
 
     # :flag.usage
+    printf "  %s\n" "--clear"
+    printf "    Remove all stored configuration and credentials (no prompt)\n"
+    echo
+
+    # :flag.usage
     printf "  %s\n" "--yes, -y"
     printf "    Do not prompt for confirmation\n"
     echo
@@ -743,6 +748,13 @@ configure_run_remove() {
   _confirm "Remove the stored altertable credential?" || { printf 'Aborted.\n' >&2; return 0; }
   configure_clear_all
   printf 'Removed stored credential.\n' >&2
+  return 0
+}
+
+configure_run_clear() {
+  configure_clear_all
+  rm -f "$(config_file)" "$(credentials_file)"
+  printf 'Cleared all altertable configuration.\n' >&2
   return 0
 }
 
@@ -1101,6 +1113,8 @@ altertable_configure_command() {
     configure_run_list
   elif [[ -n "${args[--remove]:-}" ]]; then
     configure_run_remove
+  elif [[ -n "${args[--clear]:-}" ]]; then
+    configure_run_clear
   else
     configure_run_set
   fi
@@ -2050,6 +2064,14 @@ altertable_configure_parse_requirements() {
 
         # :flag.case_no_arg
         args['--remove']=1
+        shift
+        ;;
+
+      # :flag.case
+      --clear)
+
+        # :flag.case_no_arg
+        args['--clear']=1
         shift
         ;;
 

--- a/bin/altertable
+++ b/bin/altertable
@@ -724,7 +724,25 @@ configure_run_set() {
 }
 
 # Stubs replaced in later tasks.
-configure_run_interactive() { log_error "interactive configure not yet available"; exit 1; }
+configure_run_interactive() {
+  local current_user user password
+  current_user="$(config_get user)"
+  if [[ -n "$current_user" ]]; then
+    printf 'Lakehouse username [%s]: ' "$current_user" >&2
+  else
+    printf 'Lakehouse username: ' >&2
+  fi
+  IFS= read -r user || true
+  [[ -z "$user" ]] && user="$current_user"
+  printf 'Lakehouse password (input hidden): ' >&2
+  IFS= read -rs password || true
+  printf '\n' >&2
+  [[ -z "$user" ]] && { log_error "Username is required."; exit 1; }
+  [[ -z "$password" ]] && { log_error "Password is required."; exit 1; }
+  config_set user "$user"
+  secret_set "lakehouse/password" "$password"
+  printf 'Saved lakehouse credentials for user %s.\n' "$user" >&2
+}
 configure_run_list() {
   local user api_base app_base default_env e found=0
   user="$(config_get user)"

--- a/bin/altertable
+++ b/bin/altertable
@@ -414,23 +414,13 @@ altertable_configure_usage() {
     echo
 
     # :flag.usage
-    printf "  %s\n" "--list"
+    printf "  %s\n" "--show"
     printf "    Show stored configuration (secrets masked)\n"
-    echo
-
-    # :flag.usage
-    printf "  %s\n" "--remove"
-    printf "    Remove the stored credential\n"
     echo
 
     # :flag.usage
     printf "  %s\n" "--clear"
     printf "    Remove all stored configuration and credentials (no prompt)\n"
-    echo
-
-    # :flag.usage
-    printf "  %s\n" "--yes, -y"
-    printf "    Do not prompt for confirmation\n"
     echo
 
     # :flag.usage
@@ -448,8 +438,8 @@ altertable_configure_usage() {
     printf "  altertable configure\n"
     printf "  altertable configure --user u_blabla --password s_llll\n"
     printf "  altertable configure --api-key atm_xxxx --env production\n"
-    printf "  altertable configure --list\n"
-    printf "  altertable configure --remove\n"
+    printf "  altertable configure --show\n"
+    printf "  altertable configure --clear\n"
     echo
 
   fi
@@ -708,7 +698,7 @@ configure_run_interactive() {
   printf 'Saved lakehouse credentials for user %s.\n' "$user" >&2
 }
 
-configure_run_list() {
+configure_run_show() {
   local store_display
   case "$(secret_backend)" in
     macos) store_display="MacOS keychain" ;;
@@ -733,21 +723,6 @@ configure_run_list() {
   else
     printf '  No credentials configured. Run: altertable configure\n'
   fi
-  return 0
-}
-
-_confirm() {
-  local msg="$1" ans
-  [[ -n "${args[--yes]:-}" ]] && return 0
-  printf '%s [y/N] ' "$msg" >&2
-  IFS= read -r ans || true
-  [[ "$ans" == "y" || "$ans" == "Y" ]]
-}
-
-configure_run_remove() {
-  _confirm "Remove the stored altertable credential?" || { printf 'Aborted.\n' >&2; return 0; }
-  configure_clear_all
-  printf 'Removed stored credential.\n' >&2
   return 0
 }
 
@@ -1109,10 +1084,8 @@ altertable_configure_command() {
 
   # src/configure_command.sh
   # Dispatch configure modes. Behavior lives in src/lib/configure.sh.
-  if [[ -n "${args[--list]:-}" ]]; then
-    configure_run_list
-  elif [[ -n "${args[--remove]:-}" ]]; then
-    configure_run_remove
+  if [[ -n "${args[--show]:-}" ]]; then
+    configure_run_show
   elif [[ -n "${args[--clear]:-}" ]]; then
     configure_run_clear
   else
@@ -2052,18 +2025,10 @@ altertable_configure_parse_requirements() {
         ;;
 
       # :flag.case
-      --list)
+      --show)
 
         # :flag.case_no_arg
-        args['--list']=1
-        shift
-        ;;
-
-      # :flag.case
-      --remove)
-
-        # :flag.case_no_arg
-        args['--remove']=1
+        args['--show']=1
         shift
         ;;
 
@@ -2072,14 +2037,6 @@ altertable_configure_parse_requirements() {
 
         # :flag.case_no_arg
         args['--clear']=1
-        shift
-        ;;
-
-      # :flag.case
-      --yes | -y)
-
-        # :flag.case_no_arg
-        args['--yes']=1
         shift
         ;;
 

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -10,7 +10,17 @@ environment_variables:
 - name: altertable_basic_auth_token
   help: Pre-encoded Basic Auth Token (optional)
 - name: altertable_api_base
-  help: "API Base URL (default: https://api.altertable.ai)"
+  help: "Data plane API Base URL (default: https://api.altertable.ai)"
+- name: altertable_app_base
+  help: "Management API Base URL (default: https://app.altertable.ai)"
+- name: altertable_api_key
+  help: Management API key (overrides stored value)
+- name: altertable_env
+  help: Default environment for management operations
+- name: altertable_config_home
+  help: "Config/credentials directory (default: $XDG_CONFIG_HOME/altertable)"
+- name: altertable_secret_backend
+  help: "Force secret storage backend: keychain | file (default: auto-detect)"
 
 flags:
 - &debug_flag
@@ -119,4 +129,62 @@ commands:
     arg: uuid
     help: Session id that owns the query
     required: true
+  - *debug_flag
+
+- name: configure
+  help: Configure and securely store credentials and settings.
+  examples:
+  - altertable configure
+  - altertable configure --user u_blabla --password s_llll
+  - altertable configure --api-key atm_xxxx --env production
+  - altertable configure --list
+  - altertable configure --remove --env production
+  flags:
+  - long: --user
+    arg: username
+    help: Lakehouse username (global)
+  - long: --password
+    arg: password
+    help: Lakehouse password (global)
+    conflicts: [--password-stdin]
+  - long: --password-stdin
+    help: Read the lakehouse password from stdin
+    conflicts: [--password, --api-key-stdin]
+  - long: --basic-token
+    arg: token
+    help: Pre-encoded HTTP Basic token (alternative to user/password)
+  - long: --api-key
+    arg: key
+    help: Management API key for the --env environment
+    needs: [--env]
+    conflicts: [--api-key-stdin]
+  - long: --api-key-stdin
+    help: Read the management API key from stdin
+    needs: [--env]
+    conflicts: [--api-key, --password-stdin]
+  - long: --env
+    arg: name
+    help: Target environment (management API keys are per-environment)
+  - long: --default
+    help: Mark the --env environment as the default
+    needs: [--env]
+  - long: --api-base
+    arg: url
+    help: Override the data-plane base URL
+  - long: --app-base
+    arg: url
+    help: Override the management base URL
+  - long: --list
+    help: Show stored configuration (secrets masked)
+  - long: --remove
+    help: Remove stored credentials (with --env, --lakehouse, or --all)
+  - long: --lakehouse
+    help: With --remove, remove the global lakehouse credential
+    needs: [--remove]
+  - long: --all
+    help: With --remove, remove all stored credentials and config
+    needs: [--remove]
+  - long: --yes
+    short: -y
+    help: Do not prompt for confirmation
   - *debug_flag

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -163,6 +163,8 @@ commands:
     help: Show stored configuration (secrets masked)
   - long: --remove
     help: Remove the stored credential
+  - long: --clear
+    help: Remove all stored configuration and credentials (no prompt)
   - long: --yes
     short: -y
     help: Do not prompt for confirmation

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -131,8 +131,8 @@ commands:
   - altertable configure
   - altertable configure --user u_blabla --password s_llll
   - altertable configure --api-key atm_xxxx --env production
-  - altertable configure --list
-  - altertable configure --remove
+  - altertable configure --show
+  - altertable configure --clear
   flags:
   - long: --user
     arg: username
@@ -159,13 +159,8 @@ commands:
   - long: --env
     arg: name
     help: Target environment (management API keys are per-environment)
-  - long: --list
+  - long: --show
     help: Show stored configuration (secrets masked)
-  - long: --remove
-    help: Remove the stored credential
   - long: --clear
     help: Remove all stored configuration and credentials (no prompt)
-  - long: --yes
-    short: -y
-    help: Do not prompt for confirmation
   - *debug_flag

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -11,12 +11,6 @@ environment_variables:
   help: Pre-encoded Basic Auth Token (optional)
 - name: altertable_api_base
   help: "Data plane API Base URL (default: https://api.altertable.ai)"
-- name: altertable_app_base
-  help: "Management API Base URL (default: https://app.altertable.ai)"
-- name: altertable_api_key
-  help: Management API key (overrides stored value)
-- name: altertable_env
-  help: Default environment for management operations
 - name: altertable_config_home
   help: "Config/credentials directory (default: $XDG_CONFIG_HOME/altertable)"
 - name: altertable_secret_backend
@@ -138,7 +132,7 @@ commands:
   - altertable configure --user u_blabla --password s_llll
   - altertable configure --api-key atm_xxxx --env production
   - altertable configure --list
-  - altertable configure --remove --env production
+  - altertable configure --remove
   flags:
   - long: --user
     arg: username
@@ -165,25 +159,10 @@ commands:
   - long: --env
     arg: name
     help: Target environment (management API keys are per-environment)
-  - long: --default
-    help: Mark the --env environment as the default
-    needs: [--env]
-  - long: --api-base
-    arg: url
-    help: Override the data-plane base URL
-  - long: --app-base
-    arg: url
-    help: Override the management base URL
   - long: --list
     help: Show stored configuration (secrets masked)
   - long: --remove
-    help: Remove stored credentials (with --env, --lakehouse, or --all)
-  - long: --lakehouse
-    help: With --remove, remove the global lakehouse credential
-    needs: [--remove]
-  - long: --all
-    help: With --remove, remove all stored credentials and config
-    needs: [--remove]
+    help: Remove the stored credential
   - long: --yes
     short: -y
     help: Do not prompt for confirmation

--- a/src/configure_command.sh
+++ b/src/configure_command.sh
@@ -3,6 +3,8 @@ if [[ -n "${args[--list]:-}" ]]; then
   configure_run_list
 elif [[ -n "${args[--remove]:-}" ]]; then
   configure_run_remove
+elif [[ -n "${args[--clear]:-}" ]]; then
+  configure_run_clear
 else
   configure_run_set
 fi

--- a/src/configure_command.sh
+++ b/src/configure_command.sh
@@ -1,0 +1,8 @@
+# Dispatch configure modes. Behavior lives in src/lib/configure.sh.
+if [[ -n "${args[--list]:-}" ]]; then
+  configure_run_list
+elif [[ -n "${args[--remove]:-}" ]]; then
+  configure_run_remove
+else
+  configure_run_set
+fi

--- a/src/configure_command.sh
+++ b/src/configure_command.sh
@@ -1,8 +1,6 @@
 # Dispatch configure modes. Behavior lives in src/lib/configure.sh.
-if [[ -n "${args[--list]:-}" ]]; then
-  configure_run_list
-elif [[ -n "${args[--remove]:-}" ]]; then
-  configure_run_remove
+if [[ -n "${args[--show]:-}" ]]; then
+  configure_run_show
 elif [[ -n "${args[--clear]:-}" ]]; then
   configure_run_clear
 else

--- a/src/lib/auth.sh
+++ b/src/lib/auth.sh
@@ -1,12 +1,26 @@
 get_auth_header() {
+  local token user pass
   if [[ -n "${ALTERTABLE_BASIC_AUTH_TOKEN:-}" ]]; then
     echo "Authorization: Basic ${ALTERTABLE_BASIC_AUTH_TOKEN}"
-  elif [[ -n "${ALTERTABLE_LAKEHOUSE_USERNAME:-}" && -n "${ALTERTABLE_LAKEHOUSE_PASSWORD:-}" ]]; then
-    local token
-    token=$(echo -n "${ALTERTABLE_LAKEHOUSE_USERNAME}:${ALTERTABLE_LAKEHOUSE_PASSWORD}" | base64 | tr -d '\n')
-    echo "Authorization: Basic ${token}"
-  else
-    log_error "Missing authentication. Set ALTERTABLE_LAKEHOUSE_USERNAME/PASSWORD or ALTERTABLE_BASIC_AUTH_TOKEN."
-    exit 1
+    return 0
   fi
+  if [[ -n "${ALTERTABLE_LAKEHOUSE_USERNAME:-}" && -n "${ALTERTABLE_LAKEHOUSE_PASSWORD:-}" ]]; then
+    token=$(printf '%s' "${ALTERTABLE_LAKEHOUSE_USERNAME}:${ALTERTABLE_LAKEHOUSE_PASSWORD}" | base64 | tr -d '\n')
+    echo "Authorization: Basic ${token}"
+    return 0
+  fi
+  token="$(secret_get 'lakehouse/basic-token')"
+  if [[ -n "$token" ]]; then
+    echo "Authorization: Basic ${token}"
+    return 0
+  fi
+  user="$(config_get user)"
+  pass="$(secret_get 'lakehouse/password')"
+  if [[ -n "$user" && -n "$pass" ]]; then
+    token=$(printf '%s' "${user}:${pass}" | base64 | tr -d '\n')
+    echo "Authorization: Basic ${token}"
+    return 0
+  fi
+  log_error "No credentials. Run 'altertable configure' or set ALTERTABLE_LAKEHOUSE_USERNAME/PASSWORD (or ALTERTABLE_BASIC_AUTH_TOKEN)."
+  exit 1
 }

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -1,0 +1,94 @@
+# Non-secret configuration: a flat "key=value" file plus base-URL resolution.
+
+trim() { printf '%s' "$1" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'; }
+
+config_dir() { echo "${ALTERTABLE_CONFIG_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/altertable}"; }
+config_file() { echo "$(config_dir)/config"; }
+credentials_file() { echo "$(config_dir)/credentials"; }
+
+# Flat "key=value" helpers (tolerant of surrounding whitespace, comments preserved).
+kv_get() {
+  local file="$1" key="$2" line k
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    k="$(trim "${line%%=*}")"
+    if [[ "$k" == "$key" ]]; then
+      trim "${line#*=}"
+      printf '\n'
+      return 0
+    fi
+  done < "$file"
+  return 0
+}
+
+kv_set() {
+  local file="$1" key="$2" value="$3" tmp line k found=0
+  mkdir -p "$(dirname "$file")"
+  tmp="$(mktemp)"
+  if [[ -f "$file" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      k="$(trim "${line%%=*}")"
+      if [[ "$k" == "$key" ]]; then
+        printf '%s=%s\n' "$key" "$value" >> "$tmp"
+        found=1
+      else
+        printf '%s\n' "$line" >> "$tmp"
+      fi
+    done < "$file"
+  fi
+  [[ "$found" -eq 0 ]] && printf '%s=%s\n' "$key" "$value" >> "$tmp"
+  mv "$tmp" "$file"
+}
+
+kv_unset() {
+  local file="$1" key="$2" tmp line k
+  [[ -f "$file" ]] || return 0
+  tmp="$(mktemp)"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    k="$(trim "${line%%=*}")"
+    [[ "$k" == "$key" ]] && continue
+    printf '%s\n' "$line" >> "$tmp"
+  done < "$file"
+  mv "$tmp" "$file"
+}
+
+config_get() { kv_get "$(config_file)" "$1"; }
+config_set() { local f; f="$(config_file)"; kv_set "$f" "$1" "$2"; chmod 600 "$f" 2>/dev/null || true; }
+config_unset() { kv_unset "$(config_file)" "$1"; }
+
+# The comma-separated "environments" list (one env per line on output).
+config_envs() {
+  local raw; raw="$(config_get environments)"
+  [[ -z "$raw" ]] && return 0
+  printf '%s\n' "$raw" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' || true
+}
+config_env_exists() {
+  local target="$1" e
+  while IFS= read -r e; do [[ "$e" == "$target" ]] && return 0; done < <(config_envs)
+  return 1
+}
+config_add_env() {
+  local env="$1" joined
+  config_env_exists "$env" && return 0
+  joined="$( { config_envs; printf '%s\n' "$env"; } | grep -v '^$' | paste -sd, - || true)"
+  config_set environments "$joined"
+}
+config_remove_env_from_list() {
+  local env="$1" joined
+  joined="$(config_envs | grep -vx "$env" | paste -sd, - || true)"
+  if [[ -z "$joined" ]]; then config_unset environments; else config_set environments "$joined"; fi
+}
+
+resolve_api_base() {
+  if [[ -n "${ALTERTABLE_API_BASE:-}" ]]; then echo "${ALTERTABLE_API_BASE}"; return 0; fi
+  local c; c="$(config_get api_base)"
+  if [[ -n "$c" ]]; then echo "$c"; return 0; fi
+  echo "https://api.altertable.ai"
+}
+resolve_app_base() {
+  if [[ -n "${ALTERTABLE_APP_BASE:-}" ]]; then echo "${ALTERTABLE_APP_BASE}"; return 0; fi
+  local c; c="$(config_get app_base)"
+  if [[ -n "$c" ]]; then echo "$c"; return 0; fi
+  echo "https://app.altertable.ai"
+}

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -57,38 +57,4 @@ config_get() { kv_get "$(config_file)" "$1"; }
 config_set() { local f; f="$(config_file)"; kv_set "$f" "$1" "$2"; chmod 600 "$f" 2>/dev/null || true; }
 config_unset() { kv_unset "$(config_file)" "$1"; }
 
-# The comma-separated "environments" list (one env per line on output).
-config_envs() {
-  local raw; raw="$(config_get environments)"
-  [[ -z "$raw" ]] && return 0
-  printf '%s\n' "$raw" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' || true
-}
-config_env_exists() {
-  local target="$1" e
-  while IFS= read -r e; do [[ "$e" == "$target" ]] && return 0; done < <(config_envs)
-  return 1
-}
-config_add_env() {
-  local env="$1" joined
-  config_env_exists "$env" && return 0
-  joined="$( { config_envs; printf '%s\n' "$env"; } | grep -v '^$' | paste -sd, - || true)"
-  config_set environments "$joined"
-}
-config_remove_env_from_list() {
-  local env="$1" joined
-  joined="$(config_envs | grep -vx "$env" | paste -sd, - || true)"
-  if [[ -z "$joined" ]]; then config_unset environments; else config_set environments "$joined"; fi
-}
-
-resolve_api_base() {
-  if [[ -n "${ALTERTABLE_API_BASE:-}" ]]; then echo "${ALTERTABLE_API_BASE}"; return 0; fi
-  local c; c="$(config_get api_base)"
-  if [[ -n "$c" ]]; then echo "$c"; return 0; fi
-  echo "https://api.altertable.ai"
-}
-resolve_app_base() {
-  if [[ -n "${ALTERTABLE_APP_BASE:-}" ]]; then echo "${ALTERTABLE_APP_BASE}"; return 0; fi
-  local c; c="$(config_get app_base)"
-  if [[ -n "$c" ]]; then echo "$c"; return 0; fi
-  echo "https://app.altertable.ai"
-}
+resolve_api_base() { echo "${ALTERTABLE_API_BASE:-https://api.altertable.ai}"; }

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -79,4 +79,41 @@ configure_run_list() {
   [[ "$found" -eq 0 ]] && printf '    (none configured)\n'
   return 0
 }
-configure_run_remove() { log_error "configure --remove not yet available"; exit 1; }
+_confirm() {
+  local msg="$1" ans
+  [[ -n "${args[--yes]:-}" ]] && return 0
+  printf '%s [y/N] ' "$msg" >&2
+  IFS= read -r ans || true
+  [[ "$ans" == "y" || "$ans" == "Y" ]]
+}
+
+configure_run_remove() {
+  local env="${args[--env]:-}" e
+  if [[ -n "${args[--all]:-}" ]]; then
+    _confirm "Remove ALL altertable credentials and configuration?" || { printf 'Aborted.\n' >&2; return; }
+    while IFS= read -r e; do [[ -n "$e" ]] && secret_delete "apikey/${e}"; done < <(config_envs)
+    secret_delete "lakehouse/password"
+    secret_delete "lakehouse/basic-token"
+    rm -f "$(config_file)" "$(credentials_file)"
+    printf 'Removed all altertable credentials and configuration.\n' >&2
+    return
+  fi
+  if [[ -n "${args[--lakehouse]:-}" ]]; then
+    _confirm "Remove the global lakehouse credential?" || { printf 'Aborted.\n' >&2; return; }
+    secret_delete "lakehouse/password"
+    secret_delete "lakehouse/basic-token"
+    config_unset user
+    printf 'Removed lakehouse credential.\n' >&2
+    return
+  fi
+  if [[ -z "$env" ]]; then
+    log_error "Specify what to remove: --env <name>, --lakehouse, or --all."
+    exit 1
+  fi
+  config_env_exists "$env" || { log_error "No configuration for environment '${env}'."; exit 1; }
+  _confirm "Remove API key for environment '${env}'?" || { printf 'Aborted.\n' >&2; return; }
+  secret_delete "apikey/${env}"
+  config_remove_env_from_list "$env"
+  [[ "$(config_get default_env)" == "$env" ]] && config_unset default_env
+  printf "Removed API key for environment '%s'.\n" "$env" >&2
+}

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -10,7 +10,15 @@ configure_run_set() {
   local app_base="${args[--app-base]:-}"
   local env="${args[--env]:-}"
 
-  # === stdin + --env validation: see Task 3 ===
+  # Read secrets from stdin when requested (mutual exclusion is enforced by bashly).
+  if [[ -n "${args[--password-stdin]:-}" ]]; then IFS= read -r password || true; fi
+  if [[ -n "${args[--api-key-stdin]:-}" ]]; then IFS= read -r api_key || true; fi
+
+  # --env applies only to --api-key/--default; lakehouse credentials are global.
+  if [[ -n "$env" && -z "$api_key" && -z "${args[--api-key-stdin]:-}" && -z "${args[--default]:-}" ]]; then
+    log_error "--env applies only to --api-key/--default; lakehouse credentials are global."
+    exit 1
+  fi
 
   # Interactive when nothing was provided.
   if [[ -z "$user" && -z "$password" && -z "$basic_token" && -z "$api_key" \

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -1,0 +1,39 @@
+# Operations behind `altertable configure`. These read the global `args` array
+# (set by bashly), consistent with the other libraries.
+
+configure_run_set() {
+  local user="${args[--user]:-}"
+  local password="${args[--password]:-}"
+  local basic_token="${args[--basic-token]:-}"
+  local api_key="${args[--api-key]:-}"
+  local api_base="${args[--api-base]:-}"
+  local app_base="${args[--app-base]:-}"
+  local env="${args[--env]:-}"
+
+  # === stdin + --env validation: see Task 3 ===
+
+  # Interactive when nothing was provided.
+  if [[ -z "$user" && -z "$password" && -z "$basic_token" && -z "$api_key" \
+        && -z "$api_base" && -z "$app_base" && -z "$env" \
+        && -z "${args[--password-stdin]:-}" && -z "${args[--api-key-stdin]:-}" \
+        && -z "${args[--default]:-}" ]]; then
+    configure_run_interactive
+    return
+  fi
+
+  # Lakehouse credentials (global).
+  [[ -n "$user" ]] && config_set user "$user"
+  [[ -n "$password" ]] && secret_set "lakehouse/password" "$password"
+  [[ -n "$basic_token" ]] && secret_set "lakehouse/basic-token" "$basic_token"
+  [[ -n "$api_base" ]] && config_set api_base "$api_base"
+  [[ -n "$app_base" ]] && config_set app_base "$app_base"
+
+  # === management API key: see Task 2 ===
+
+  printf 'Configuration updated.\n' >&2
+}
+
+# Stubs replaced in later tasks.
+configure_run_interactive() { log_error "interactive configure not yet available"; exit 1; }
+configure_run_list() { log_error "configure --list not yet available"; exit 1; }
+configure_run_remove() { log_error "configure --remove not yet available"; exit 1; }

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -28,7 +28,17 @@ configure_run_set() {
   [[ -n "$api_base" ]] && config_set api_base "$api_base"
   [[ -n "$app_base" ]] && config_set app_base "$app_base"
 
-  # === management API key: see Task 2 ===
+  # Management API key (per environment; --env is guaranteed present by bashly `needs`).
+  if [[ -n "$api_key" ]]; then
+    secret_set "apikey/${env}" "$api_key"
+    config_add_env "$env"
+    if [[ -z "$(config_get default_env)" || -n "${args[--default]:-}" ]]; then
+      config_set default_env "$env"
+    fi
+  elif [[ -n "${args[--default]:-}" ]]; then
+    config_env_exists "$env" || { log_error "Unknown environment '${env}'. Configure an API key for it first."; exit 1; }
+    config_set default_env "$env"
+  fi
 
   printf 'Configuration updated.\n' >&2
 }

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -52,7 +52,25 @@ configure_run_set() {
 }
 
 # Stubs replaced in later tasks.
-configure_run_interactive() { log_error "interactive configure not yet available"; exit 1; }
+configure_run_interactive() {
+  local current_user user password
+  current_user="$(config_get user)"
+  if [[ -n "$current_user" ]]; then
+    printf 'Lakehouse username [%s]: ' "$current_user" >&2
+  else
+    printf 'Lakehouse username: ' >&2
+  fi
+  IFS= read -r user || true
+  [[ -z "$user" ]] && user="$current_user"
+  printf 'Lakehouse password (input hidden): ' >&2
+  IFS= read -rs password || true
+  printf '\n' >&2
+  [[ -z "$user" ]] && { log_error "Username is required."; exit 1; }
+  [[ -z "$password" ]] && { log_error "Password is required."; exit 1; }
+  config_set user "$user"
+  secret_set "lakehouse/password" "$password"
+  printf 'Saved lakehouse credentials for user %s.\n' "$user" >&2
+}
 configure_run_list() {
   local user api_base app_base default_env e found=0
   user="$(config_get user)"

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -51,7 +51,6 @@ configure_run_set() {
   printf 'Configuration updated.\n' >&2
 }
 
-# Stubs replaced in later tasks.
 configure_run_interactive() {
   local current_user user password
   current_user="$(config_get user)"

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -94,7 +94,7 @@ configure_run_interactive() {
   printf 'Saved lakehouse credentials for user %s.\n' "$user" >&2
 }
 
-configure_run_list() {
+configure_run_show() {
   local store_display
   case "$(secret_backend)" in
     macos) store_display="MacOS keychain" ;;
@@ -119,21 +119,6 @@ configure_run_list() {
   else
     printf '  No credentials configured. Run: altertable configure\n'
   fi
-  return 0
-}
-
-_confirm() {
-  local msg="$1" ans
-  [[ -n "${args[--yes]:-}" ]] && return 0
-  printf '%s [y/N] ' "$msg" >&2
-  IFS= read -r ans || true
-  [[ "$ans" == "y" || "$ans" == "Y" ]]
-}
-
-configure_run_remove() {
-  _confirm "Remove the stored altertable credential?" || { printf 'Aborted.\n' >&2; return 0; }
-  configure_clear_all
-  printf 'Removed stored credential.\n' >&2
   return 0
 }
 

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -1,53 +1,75 @@
 # Operations behind `altertable configure`. These read the global `args` array
-# (set by bashly), consistent with the other libraries.
+# (set by bashly), consistent with the other libraries. A new `configure` always
+# REPLACES any previously stored credential — mechanisms are never combined.
+
+# Remove every stored credential and auth identity.
+configure_clear_all() {
+  secret_delete "lakehouse/password"
+  secret_delete "lakehouse/basic-token"
+  secret_delete "api-key"
+  config_unset user
+  config_unset api_key_env
+}
 
 configure_run_set() {
   local user="${args[--user]:-}"
   local password="${args[--password]:-}"
   local basic_token="${args[--basic-token]:-}"
   local api_key="${args[--api-key]:-}"
-  local api_base="${args[--api-base]:-}"
-  local app_base="${args[--app-base]:-}"
   local env="${args[--env]:-}"
+  local want_pw_stdin="${args[--password-stdin]:-}"
+  local want_key_stdin="${args[--api-key-stdin]:-}"
 
-  # Read secrets from stdin when requested (mutual exclusion is enforced by bashly).
-  if [[ -n "${args[--password-stdin]:-}" ]]; then IFS= read -r password || true; fi
-  if [[ -n "${args[--api-key-stdin]:-}" ]]; then IFS= read -r api_key || true; fi
+  # No input at all -> interactive lakehouse setup.
+  if [[ -z "$user$password$basic_token$api_key$env$want_pw_stdin$want_key_stdin" ]]; then
+    configure_run_interactive
+    return 0
+  fi
 
-  # --env applies only to --api-key/--default; lakehouse credentials are global.
-  if [[ -n "$env" && -z "$api_key" && -z "${args[--api-key-stdin]:-}" && -z "${args[--default]:-}" ]]; then
-    log_error "--env applies only to --api-key/--default; lakehouse credentials are global."
+  if [[ -n "$want_pw_stdin" ]]; then IFS= read -r password || true; fi
+  if [[ -n "$want_key_stdin" ]]; then IFS= read -r api_key || true; fi
+
+  # Identify the requested mechanism; at most one is allowed.
+  local m_lakehouse="" m_token="" m_apikey="" count=0
+  [[ -n "$user" || -n "$password" ]] && m_lakehouse=1
+  [[ -n "$basic_token" ]] && m_token=1
+  [[ -n "$api_key" ]] && m_apikey=1
+  [[ -n "$m_lakehouse" ]] && count=$((count + 1))
+  [[ -n "$m_token" ]] && count=$((count + 1))
+  [[ -n "$m_apikey" ]] && count=$((count + 1))
+
+  if [[ "$count" -gt 1 ]]; then
+    log_error "Choose a single authentication mechanism: --user/--password, --basic-token, or --api-key (they cannot be combined)."
+    exit 1
+  fi
+  if [[ -n "$env" && -z "$m_apikey" ]]; then
+    log_error "--env applies only to --api-key."
+    exit 1
+  fi
+  if [[ "$count" -eq 0 ]]; then
+    log_error "Nothing to configure. Use --user/--password, --basic-token, or --api-key --env <name>."
+    exit 1
+  fi
+  if [[ -n "$m_lakehouse" && ( -z "$user" || -z "$password" ) ]]; then
+    log_error "--user and --password must be provided together."
+    exit 1
+  fi
+  if [[ -n "$m_apikey" && -z "$env" ]]; then
+    log_error "--api-key requires --env <name>."
     exit 1
   fi
 
-  # Interactive when nothing was provided.
-  if [[ -z "$user" && -z "$password" && -z "$basic_token" && -z "$api_key" \
-        && -z "$api_base" && -z "$app_base" && -z "$env" \
-        && -z "${args[--password-stdin]:-}" && -z "${args[--api-key-stdin]:-}" \
-        && -z "${args[--default]:-}" ]]; then
-    configure_run_interactive
-    return
+  # Override: a new configuration replaces any previous one.
+  configure_clear_all
+  if [[ -n "$m_apikey" ]]; then
+    secret_set "api-key" "$api_key"
+    config_set api_key_env "$env"
+  elif [[ -n "$m_token" ]]; then
+    secret_set "lakehouse/basic-token" "$basic_token"
+  else
+    config_set user "$user"
+    secret_set "lakehouse/password" "$password"
   fi
-
-  # Lakehouse credentials (global).
-  [[ -n "$user" ]] && config_set user "$user"
-  [[ -n "$password" ]] && secret_set "lakehouse/password" "$password"
-  [[ -n "$basic_token" ]] && secret_set "lakehouse/basic-token" "$basic_token"
-  [[ -n "$api_base" ]] && config_set api_base "$api_base"
-  [[ -n "$app_base" ]] && config_set app_base "$app_base"
-
-  # Management API key (per environment; --env is guaranteed present by bashly `needs`).
-  if [[ -n "$api_key" ]]; then
-    secret_set "apikey/${env}" "$api_key"
-    config_add_env "$env"
-    if [[ -z "$(config_get default_env)" || -n "${args[--default]:-}" ]]; then
-      config_set default_env "$env"
-    fi
-  elif [[ -n "${args[--default]:-}" ]]; then
-    config_env_exists "$env" || { log_error "Unknown environment '${env}'. Configure an API key for it first."; exit 1; }
-    config_set default_env "$env"
-  fi
-
   printf 'Configuration updated.\n' >&2
 }
 
@@ -66,36 +88,40 @@ configure_run_interactive() {
   printf '\n' >&2
   [[ -z "$user" ]] && { log_error "Username is required."; exit 1; }
   [[ -z "$password" ]] && { log_error "Password is required."; exit 1; }
+  configure_clear_all
   config_set user "$user"
   secret_set "lakehouse/password" "$password"
   printf 'Saved lakehouse credentials for user %s.\n' "$user" >&2
 }
-configure_run_list() {
-  local user api_base app_base default_env e found=0
-  user="$(config_get user)"
-  api_base="$(resolve_api_base)"
-  app_base="$(resolve_app_base)"
-  default_env="$(config_get default_env)"
 
+configure_run_list() {
+  local store_display
+  case "$(secret_backend)" in
+    macos) store_display="MacOS keychain" ;;
+    *)     store_display="$(credentials_file)" ;;
+  esac
   printf 'Altertable CLI configuration\n'
   printf '  Config dir:    %s\n' "$(config_dir)"
-  printf '  Secret store:  %s\n' "$(secret_backend)"
-  printf '\n  Lakehouse (data plane):\n'
-  printf '    user:        %s\n' "${user:-(not set)}"
-  if secret_exists "lakehouse/password"; then printf '    password:    set\n'; else printf '    password:    (not set)\n'; fi
-  if secret_exists "lakehouse/basic-token"; then printf '    basic-token: set\n'; fi
-  printf '    api_base:    %s\n' "$api_base"
-  printf '\n  Management API keys (by environment):\n'
-  printf '    app_base:    %s\n' "$app_base"
-  printf '    default env: %s\n' "${default_env:-(none)}"
-  while IFS= read -r e; do
-    [[ -z "$e" ]] && continue
-    found=1
-    if secret_exists "apikey/${e}"; then printf '    %s: set\n' "$e"; else printf '    %s: (listed, no key)\n' "$e"; fi
-  done < <(config_envs)
-  [[ "$found" -eq 0 ]] && printf '    (none configured)\n'
+  printf '  Secret store:  %s\n' "$store_display"
+  printf '  Data plane:    %s\n' "$(resolve_api_base)"
+  printf '\n'
+  if secret_exists "api-key"; then
+    printf '  Authentication: management API key\n'
+    printf '    environment:  %s\n' "$(config_get api_key_env)"
+    printf '    api key:      set\n'
+  elif secret_exists "lakehouse/basic-token"; then
+    printf '  Authentication: lakehouse Basic token\n'
+    printf '    basic token:  set\n'
+  elif secret_exists "lakehouse/password"; then
+    printf '  Authentication: lakehouse username/password\n'
+    printf '    user:         %s\n' "$(config_get user)"
+    printf '    password:     set\n'
+  else
+    printf '  No credentials configured. Run: altertable configure\n'
+  fi
   return 0
 }
+
 _confirm() {
   local msg="$1" ans
   [[ -n "${args[--yes]:-}" ]] && return 0
@@ -105,32 +131,8 @@ _confirm() {
 }
 
 configure_run_remove() {
-  local env="${args[--env]:-}" e
-  if [[ -n "${args[--all]:-}" ]]; then
-    _confirm "Remove ALL altertable credentials and configuration?" || { printf 'Aborted.\n' >&2; return; }
-    while IFS= read -r e; do [[ -n "$e" ]] && secret_delete "apikey/${e}"; done < <(config_envs)
-    secret_delete "lakehouse/password"
-    secret_delete "lakehouse/basic-token"
-    rm -f "$(config_file)" "$(credentials_file)"
-    printf 'Removed all altertable credentials and configuration.\n' >&2
-    return
-  fi
-  if [[ -n "${args[--lakehouse]:-}" ]]; then
-    _confirm "Remove the global lakehouse credential?" || { printf 'Aborted.\n' >&2; return; }
-    secret_delete "lakehouse/password"
-    secret_delete "lakehouse/basic-token"
-    config_unset user
-    printf 'Removed lakehouse credential.\n' >&2
-    return
-  fi
-  if [[ -z "$env" ]]; then
-    log_error "Specify what to remove: --env <name>, --lakehouse, or --all."
-    exit 1
-  fi
-  config_env_exists "$env" || { log_error "No configuration for environment '${env}'."; exit 1; }
-  _confirm "Remove API key for environment '${env}'?" || { printf 'Aborted.\n' >&2; return; }
-  secret_delete "apikey/${env}"
-  config_remove_env_from_list "$env"
-  [[ "$(config_get default_env)" == "$env" ]] && config_unset default_env
-  printf "Removed API key for environment '%s'.\n" "$env" >&2
+  _confirm "Remove the stored altertable credential?" || { printf 'Aborted.\n' >&2; return 0; }
+  configure_clear_all
+  printf 'Removed stored credential.\n' >&2
+  return 0
 }

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -53,5 +53,30 @@ configure_run_set() {
 
 # Stubs replaced in later tasks.
 configure_run_interactive() { log_error "interactive configure not yet available"; exit 1; }
-configure_run_list() { log_error "configure --list not yet available"; exit 1; }
+configure_run_list() {
+  local user api_base app_base default_env e found=0
+  user="$(config_get user)"
+  api_base="$(resolve_api_base)"
+  app_base="$(resolve_app_base)"
+  default_env="$(config_get default_env)"
+
+  printf 'Altertable CLI configuration\n'
+  printf '  Config dir:    %s\n' "$(config_dir)"
+  printf '  Secret store:  %s\n' "$(secret_backend)"
+  printf '\n  Lakehouse (data plane):\n'
+  printf '    user:        %s\n' "${user:-(not set)}"
+  if secret_exists "lakehouse/password"; then printf '    password:    set\n'; else printf '    password:    (not set)\n'; fi
+  if secret_exists "lakehouse/basic-token"; then printf '    basic-token: set\n'; fi
+  printf '    api_base:    %s\n' "$api_base"
+  printf '\n  Management API keys (by environment):\n'
+  printf '    app_base:    %s\n' "$app_base"
+  printf '    default env: %s\n' "${default_env:-(none)}"
+  while IFS= read -r e; do
+    [[ -z "$e" ]] && continue
+    found=1
+    if secret_exists "apikey/${e}"; then printf '    %s: set\n' "$e"; else printf '    %s: (listed, no key)\n' "$e"; fi
+  done < <(config_envs)
+  [[ "$found" -eq 0 ]] && printf '    (none configured)\n'
+  return 0
+}
 configure_run_remove() { log_error "configure --remove not yet available"; exit 1; }

--- a/src/lib/configure.sh
+++ b/src/lib/configure.sh
@@ -136,3 +136,10 @@ configure_run_remove() {
   printf 'Removed stored credential.\n' >&2
   return 0
 }
+
+configure_run_clear() {
+  configure_clear_all
+  rm -f "$(config_file)" "$(credentials_file)"
+  printf 'Cleared all altertable configuration.\n' >&2
+  return 0
+}

--- a/src/lib/http.sh
+++ b/src/lib/http.sh
@@ -4,7 +4,7 @@ http_request() {
   local data="$3"
   local extra_headers=("${@:4}")
 
-  local url="${ALTERTABLE_API_BASE:-https://api.altertable.ai}${endpoint}"
+  local url; url="$(resolve_api_base)${endpoint}"
   local user_agent="altertable-lakehouse-cli/${version}"
   local auth_header
   auth_header=$(get_auth_header)

--- a/src/lib/log.sh
+++ b/src/lib/log.sh
@@ -7,3 +7,7 @@ log_debug() {
 log_error() {
   echo "[ERROR] $1" >&2
 }
+
+log_warn() {
+  echo "[WARN] $1" >&2
+}

--- a/src/lib/secret.sh
+++ b/src/lib/secret.sh
@@ -1,0 +1,70 @@
+# Secret storage: OS keychain when available, else a 0600 fallback file.
+# Accounts: lakehouse/password, lakehouse/basic-token, apikey/<env>. Service: "altertable".
+
+_warn_file_backend_once() {
+  if [[ -z "${_FILE_BACKEND_WARNED:-}" ]]; then
+    log_warn "No OS keychain found; storing secrets at $(credentials_file) (chmod 600). Prefer environment variables in CI."
+    _FILE_BACKEND_WARNED=1
+  fi
+}
+
+secret_backend() {
+  local override="${ALTERTABLE_SECRET_BACKEND:-}"
+  case "$override" in
+    file) echo "file"; return 0 ;;
+  esac
+  if [[ "$(uname)" == "Darwin" ]] && command -v security >/dev/null 2>&1; then
+    echo "macos"; return 0
+  elif command -v secret-tool >/dev/null 2>&1; then
+    echo "linux"; return 0
+  fi
+  if [[ "$override" == "keychain" ]]; then
+    log_error "ALTERTABLE_SECRET_BACKEND=keychain but no OS keychain tool was found."
+    exit 1
+  fi
+  echo "file"
+}
+
+secret_set() {
+  local account="$1" value="$2" f
+  case "$(secret_backend)" in
+    macos) security add-generic-password -U -s "altertable" -a "$account" -w "$value" >/dev/null 2>&1 \
+             || { log_error "Failed to store secret in macOS keychain ($account)."; exit 1; } ;;
+    linux) printf '%s' "$value" | secret-tool store --label="altertable $account" service "altertable" account "$account" \
+             || { log_error "Failed to store secret via secret-tool ($account)."; exit 1; } ;;
+    file)
+      f="$(credentials_file)"
+      kv_set "$f" "$account" "$value"
+      chmod 600 "$f"
+      _warn_file_backend_once
+      ;;
+  esac
+}
+
+secret_get() {
+  local account="$1" val=""
+  case "$(secret_backend)" in
+    macos) val="$(security find-generic-password -s "altertable" -a "$account" -w 2>/dev/null || true)" ;;
+    linux) val="$(secret-tool lookup service "altertable" account "$account" 2>/dev/null || true)" ;;
+    file)  val="$(kv_get "$(credentials_file)" "$account")" ;;
+  esac
+  printf '%s' "$val"
+}
+
+secret_exists() {
+  local account="$1"
+  case "$(secret_backend)" in
+    macos) security find-generic-password -s "altertable" -a "$account" >/dev/null 2>&1 ;;
+    linux) secret-tool lookup service "altertable" account "$account" >/dev/null 2>&1 ;;
+    file)  [[ -n "$(kv_get "$(credentials_file)" "$account")" ]] ;;
+  esac
+}
+
+secret_delete() {
+  local account="$1"
+  case "$(secret_backend)" in
+    macos) security delete-generic-password -s "altertable" -a "$account" >/dev/null 2>&1 || true ;;
+    linux) secret-tool clear service "altertable" account "$account" >/dev/null 2>&1 || true ;;
+    file)  kv_unset "$(credentials_file)" "$account" ;;
+  esac
+}

--- a/src/lib/secret.sh
+++ b/src/lib/secret.sh
@@ -1,9 +1,25 @@
-# Secret storage: OS keychain when available, else a 0600 fallback file.
-# Accounts: lakehouse/password, lakehouse/basic-token, apikey/<env>. Service: "altertable".
+# Secret storage: macOS Keychain when available, otherwise a 0600 file.
+# Accounts: lakehouse/password, lakehouse/basic-token, api-key. Service: "altertable".
+# We refuse to read the fallback file if its permissions are looser than 600.
+
+_file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+
+# Refuse to read the credentials file when group/other have any access.
+_require_safe_credentials_file() {
+  local f mode
+  f="$(credentials_file)"
+  [[ -f "$f" ]] || return 0
+  mode="$(_file_mode "$f")"
+  [[ -n "$mode" ]] || return 0
+  if (( (8#$mode) & 8#077 )); then
+    log_error "Refusing to read ${f}: permissions ${mode} are too open (group/other access). Run: chmod 600 ${f}"
+    exit 1
+  fi
+}
 
 _warn_file_backend_once() {
   if [[ -z "${_FILE_BACKEND_WARNED:-}" ]]; then
-    log_warn "No OS keychain found; storing secrets at $(credentials_file) (chmod 600). Prefer environment variables in CI."
+    log_warn "No macOS keychain; storing secrets at $(credentials_file) (chmod 600). Prefer environment variables in CI."
     _FILE_BACKEND_WARNED=1
   fi
 }
@@ -12,17 +28,19 @@ secret_backend() {
   local override="${ALTERTABLE_SECRET_BACKEND:-}"
   case "$override" in
     file) echo "file"; return 0 ;;
+    keychain)
+      if [[ "$(uname)" == "Darwin" ]] && command -v security >/dev/null 2>&1; then
+        echo "macos"; return 0
+      fi
+      log_error "ALTERTABLE_SECRET_BACKEND=keychain but the macOS keychain is unavailable."
+      exit 1
+      ;;
   esac
   if [[ "$(uname)" == "Darwin" ]] && command -v security >/dev/null 2>&1; then
-    echo "macos"; return 0
-  elif command -v secret-tool >/dev/null 2>&1; then
-    echo "linux"; return 0
+    echo "macos"
+  else
+    echo "file"
   fi
-  if [[ "$override" == "keychain" ]]; then
-    log_error "ALTERTABLE_SECRET_BACKEND=keychain but no OS keychain tool was found."
-    exit 1
-  fi
-  echo "file"
 }
 
 secret_set() {
@@ -30,8 +48,6 @@ secret_set() {
   case "$(secret_backend)" in
     macos) security add-generic-password -U -s "altertable" -a "$account" -w "$value" >/dev/null 2>&1 \
              || { log_error "Failed to store secret in macOS keychain ($account)."; exit 1; } ;;
-    linux) printf '%s' "$value" | secret-tool store --label="altertable $account" service "altertable" account "$account" \
-             || { log_error "Failed to store secret via secret-tool ($account)."; exit 1; } ;;
     file)
       f="$(credentials_file)"
       kv_set "$f" "$account" "$value"
@@ -45,8 +61,7 @@ secret_get() {
   local account="$1" val=""
   case "$(secret_backend)" in
     macos) val="$(security find-generic-password -s "altertable" -a "$account" -w 2>/dev/null || true)" ;;
-    linux) val="$(secret-tool lookup service "altertable" account "$account" 2>/dev/null || true)" ;;
-    file)  val="$(kv_get "$(credentials_file)" "$account")" ;;
+    file)  _require_safe_credentials_file; val="$(kv_get "$(credentials_file)" "$account")" ;;
   esac
   printf '%s' "$val"
 }
@@ -55,8 +70,7 @@ secret_exists() {
   local account="$1"
   case "$(secret_backend)" in
     macos) security find-generic-password -s "altertable" -a "$account" >/dev/null 2>&1 ;;
-    linux) secret-tool lookup service "altertable" account "$account" >/dev/null 2>&1 ;;
-    file)  [[ -n "$(kv_get "$(credentials_file)" "$account")" ]] ;;
+    file)  _require_safe_credentials_file; [[ -n "$(kv_get "$(credentials_file)" "$account")" ]] ;;
   esac
 }
 
@@ -64,7 +78,6 @@ secret_delete() {
   local account="$1"
   case "$(secret_backend)" in
     macos) security delete-generic-password -s "altertable" -a "$account" >/dev/null 2>&1 || true ;;
-    linux) secret-tool clear service "altertable" account "$account" >/dev/null 2>&1 || true ;;
     file)  kv_unset "$(credentials_file)" "$account" ;;
   esac
 }

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -75,5 +75,21 @@ printf 'atm_fromstdin' | "${CLI}" configure --api-key-stdin --env production >/d
 grep -q '^apikey/production=atm_fromstdin$' "${CRED_FILE}" || fail "configure: --api-key-stdin should store the piped key"
 pass "--api-key-stdin reads the API key from stdin"
 
+# ── Task 4: configure --list ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --user u_blabla --password s_llll >/dev/null 2>&1
+"${CLI}" configure --api-key atm_prod --env production >/dev/null 2>&1
+OUT="$("${CLI}" configure --list 2>/dev/null)"
+echo "${OUT}" | grep -q 'u_blabla' || fail "--list: should show the username"
+pass "--list shows the lakehouse username"
+echo "${OUT}" | grep -Eq 'password:[[:space:]]*set' || fail "--list: should show password as set"
+pass "--list shows the password as set"
+if echo "${OUT}" | grep -q 's_llll'; then fail "--list: must NOT print the secret value"; fi
+pass "--list never prints a secret value"
+echo "${OUT}" | grep -q 'production' || fail "--list: should list the production environment"
+pass "--list lists configured environments"
+"${CLI}" configure --list >/dev/null 2>&1 || fail "--list: should exit 0 when environments are configured"
+pass "--list exits 0 on success"
+
 echo ""
 echo -e "${GREEN}All configure tests passed.${NC}"

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Offline tests for `altertable configure`. No network, no real keychain.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/utils.sh"
+CLI="${SCRIPT_DIR}/../bin/altertable"
+
+TEST_HOME="$(mktemp -d)"
+export ALTERTABLE_CONFIG_HOME="${TEST_HOME}"
+export ALTERTABLE_SECRET_BACKEND=file
+unset ALTERTABLE_LAKEHOUSE_USERNAME ALTERTABLE_LAKEHOUSE_PASSWORD \
+      ALTERTABLE_BASIC_AUTH_TOKEN ALTERTABLE_API_KEY ALTERTABLE_ENV \
+      ALTERTABLE_API_BASE ALTERTABLE_APP_BASE 2>/dev/null || true
+
+cleanup() { rm -rf "${TEST_HOME}"; }
+trap cleanup EXIT
+
+file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
+
+CONFIG_FILE="${TEST_HOME}/config"
+CRED_FILE="${TEST_HOME}/credentials"
+
+# ── Task 1: lakehouse credential storage ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --user u_blabla --password s_llll >/dev/null 2>&1
+grep -q '^user=u_blabla$' "${CONFIG_FILE}" || fail "configure: expected user=u_blabla in config"
+pass "configure stores lakehouse username in config"
+grep -q '^lakehouse/password=s_llll$' "${CRED_FILE}" || fail "configure: expected lakehouse/password in credentials"
+pass "configure stores lakehouse password in credentials (file backend)"
+[[ "$(file_mode "${CRED_FILE}")" == "600" ]] || fail "configure: credentials must be mode 600, got $(file_mode "${CRED_FILE}")"
+pass "credentials file is chmod 600"
+
+echo ""
+echo -e "${GREEN}All configure tests passed.${NC}"

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -48,5 +48,32 @@ pass "a second environment does not change the default"
 grep -q '^default_env=staging$' "${CONFIG_FILE}" || fail "configure: --default should switch default_env"
 pass "--default switches the default environment"
 
+# ── Task 3: stdin secrets & validation ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+
+# Declarative guards from bashly.yml (conflicts / needs):
+if "${CLI}" configure --password p --password-stdin >/dev/null 2>&1 <<<"x"; then
+  fail "configure: --password and --password-stdin together should error"
+fi
+pass "--password + --password-stdin is rejected (bashly conflicts)"
+if "${CLI}" configure --api-key k >/dev/null 2>&1; then
+  fail "configure: --api-key without --env should error"
+fi
+pass "--api-key without --env is rejected (bashly needs)"
+
+# Code guard: --env only applies to --api-key/--default.
+if "${CLI}" configure --user u --env production >/dev/null 2>&1; then
+  fail "configure: --env with lakehouse-only fields should error"
+fi
+pass "--env is rejected for a lakehouse-only configure"
+
+# stdin reading:
+printf 's_fromstdin' | "${CLI}" configure --user alice --password-stdin >/dev/null 2>&1
+grep -q '^lakehouse/password=s_fromstdin$' "${CRED_FILE}" || fail "configure: --password-stdin should store the piped password"
+pass "--password-stdin reads the password from stdin"
+printf 'atm_fromstdin' | "${CLI}" configure --api-key-stdin --env production >/dev/null 2>&1
+grep -q '^apikey/production=atm_fromstdin$' "${CRED_FILE}" || fail "configure: --api-key-stdin should store the piped key"
+pass "--api-key-stdin reads the API key from stdin"
+
 echo ""
 echo -e "${GREEN}All configure tests passed.${NC}"

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -10,8 +10,7 @@ TEST_HOME="$(mktemp -d)"
 export ALTERTABLE_CONFIG_HOME="${TEST_HOME}"
 export ALTERTABLE_SECRET_BACKEND=file
 unset ALTERTABLE_LAKEHOUSE_USERNAME ALTERTABLE_LAKEHOUSE_PASSWORD \
-      ALTERTABLE_BASIC_AUTH_TOKEN ALTERTABLE_API_KEY ALTERTABLE_ENV \
-      ALTERTABLE_API_BASE ALTERTABLE_APP_BASE 2>/dev/null || true
+      ALTERTABLE_BASIC_AUTH_TOKEN ALTERTABLE_API_BASE 2>/dev/null || true
 
 cleanup() { rm -rf "${TEST_HOME}"; }
 trap cleanup EXIT
@@ -21,129 +20,21 @@ file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
 CONFIG_FILE="${TEST_HOME}/config"
 CRED_FILE="${TEST_HOME}/credentials"
 
-# ── Task 1: lakehouse credential storage ──
-rm -f "${CONFIG_FILE}" "${CRED_FILE}"
-"${CLI}" configure --user u_blabla --password s_llll >/dev/null 2>&1
-grep -q '^user=u_blabla$' "${CONFIG_FILE}" || fail "configure: expected user=u_blabla in config"
-pass "configure stores lakehouse username in config"
-grep -q '^lakehouse/password=s_llll$' "${CRED_FILE}" || fail "configure: expected lakehouse/password in credentials"
-pass "configure stores lakehouse password in credentials (file backend)"
-[[ "$(file_mode "${CRED_FILE}")" == "600" ]] || fail "configure: credentials must be mode 600, got $(file_mode "${CRED_FILE}")"
-pass "credentials file is chmod 600"
-
-# ── Task 2: API key per-environment storage ──
-rm -f "${CONFIG_FILE}" "${CRED_FILE}"
-"${CLI}" configure --api-key atm_prod --env production >/dev/null 2>&1
-grep -q '^apikey/production=atm_prod$' "${CRED_FILE}" || fail "configure: expected apikey/production in credentials"
-pass "configure stores a per-environment API key"
-grep -q '^default_env=production$' "${CONFIG_FILE}" || fail "configure: first env should become default_env"
-pass "first configured environment becomes the default"
-grep -Eq '^environments=.*production' "${CONFIG_FILE}" || fail "configure: environments should list production"
-pass "configure tracks the environment in the environments list"
-
-"${CLI}" configure --api-key atm_stg --env staging >/dev/null 2>&1
-grep -q '^default_env=production$' "${CONFIG_FILE}" || fail "configure: default_env should stay production"
-pass "a second environment does not change the default"
-"${CLI}" configure --api-key atm_stg2 --env staging --default >/dev/null 2>&1
-grep -q '^default_env=staging$' "${CONFIG_FILE}" || fail "configure: --default should switch default_env"
-pass "--default switches the default environment"
-
-# ── Task 3: stdin secrets & validation ──
-rm -f "${CONFIG_FILE}" "${CRED_FILE}"
-
-# Declarative guards from bashly.yml (conflicts / needs):
-if "${CLI}" configure --password p --password-stdin >/dev/null 2>&1 <<<"x"; then
-  fail "configure: --password and --password-stdin together should error"
-fi
-pass "--password + --password-stdin is rejected (bashly conflicts)"
-if "${CLI}" configure --api-key k >/dev/null 2>&1; then
-  fail "configure: --api-key without --env should error"
-fi
-pass "--api-key without --env is rejected (bashly needs)"
-
-# Code guard: --env only applies to --api-key/--default.
-if "${CLI}" configure --user u --env production >/dev/null 2>&1; then
-  fail "configure: --env with lakehouse-only fields should error"
-fi
-pass "--env is rejected for a lakehouse-only configure"
-
-# stdin reading:
-printf 's_fromstdin' | "${CLI}" configure --user alice --password-stdin >/dev/null 2>&1
-grep -q '^lakehouse/password=s_fromstdin$' "${CRED_FILE}" || fail "configure: --password-stdin should store the piped password"
-pass "--password-stdin reads the password from stdin"
-printf 'atm_fromstdin' | "${CLI}" configure --api-key-stdin --env production >/dev/null 2>&1
-grep -q '^apikey/production=atm_fromstdin$' "${CRED_FILE}" || fail "configure: --api-key-stdin should store the piped key"
-pass "--api-key-stdin reads the API key from stdin"
-
-# ── Task 4: configure --list ──
-rm -f "${CONFIG_FILE}" "${CRED_FILE}"
-"${CLI}" configure --user u_blabla --password s_llll >/dev/null 2>&1
-"${CLI}" configure --api-key atm_prod --env production >/dev/null 2>&1
-OUT="$("${CLI}" configure --list 2>/dev/null)"
-echo "${OUT}" | grep -q 'u_blabla' || fail "--list: should show the username"
-pass "--list shows the lakehouse username"
-echo "${OUT}" | grep -Eq 'password:[[:space:]]*set' || fail "--list: should show password as set"
-pass "--list shows the password as set"
-if echo "${OUT}" | grep -q 's_llll'; then fail "--list: must NOT print the secret value"; fi
-pass "--list never prints a secret value"
-echo "${OUT}" | grep -q 'production' || fail "--list: should list the production environment"
-pass "--list lists configured environments"
-"${CLI}" configure --list >/dev/null 2>&1 || fail "--list: should exit 0 when environments are configured"
-pass "--list exits 0 on success"
-
-# ── Task 5: configure --remove ──
-rm -f "${CONFIG_FILE}" "${CRED_FILE}"
-"${CLI}" configure --user u --password p >/dev/null 2>&1
-"${CLI}" configure --api-key atm_prod --env production >/dev/null 2>&1
-"${CLI}" configure --api-key atm_stg --env staging >/dev/null 2>&1
-
-"${CLI}" configure --remove --env production --yes >/dev/null 2>&1
-if grep -q '^apikey/production=' "${CRED_FILE}"; then fail "--remove --env: production key should be gone"; fi
-pass "--remove --env removes that environment's API key"
-if grep -q 'production' "${CONFIG_FILE}"; then fail "--remove --env: production should leave config (env list + default)"; fi
-pass "--remove --env drops the env from the list and unsets a matching default"
-
-"${CLI}" configure --remove --lakehouse --yes >/dev/null 2>&1
-if grep -q '^lakehouse/password=' "${CRED_FILE}"; then fail "--remove --lakehouse: password should be gone"; fi
-pass "--remove --lakehouse removes the lakehouse credential"
-
-if "${CLI}" configure --remove >/dev/null 2>&1; then
-  fail "--remove without a target should error"
-fi
-pass "--remove requires an explicit target"
-
-"${CLI}" configure --remove --all --yes >/dev/null 2>&1
-if [[ -f "${CRED_FILE}" ]]; then fail "--remove --all: credentials file should be gone"; fi
-pass "--remove --all clears everything"
-
-# ── Task 6: interactive configure ──
-rm -f "${CONFIG_FILE}" "${CRED_FILE}"
-printf 'alice\nsecret\n' | "${CLI}" configure >/dev/null 2>&1
-grep -q '^user=alice$' "${CONFIG_FILE}" || fail "interactive: should store the username"
-pass "interactive configure stores the username"
-grep -q '^lakehouse/password=secret$' "${CRED_FILE}" || fail "interactive: should store the password"
-pass "interactive configure stores the password"
-
-# ── Task 7: stored credentials & base URL drive requests (offline mock curl) ──
-rm -f "${CONFIG_FILE}" "${CRED_FILE}"
-
+# A fake `curl` placed first on PATH: logs the Authorization header, returns 200.
 setup_curl_mock() {
   _CURL_MOCK_DIR="$(mktemp -d)"
   export _CURL_MOCK_AUTH_LOG="${_CURL_MOCK_DIR}/auth.log"
-  export _CURL_MOCK_URL_LOG="${_CURL_MOCK_DIR}/url.log"
-  : > "${_CURL_MOCK_AUTH_LOG}"; : > "${_CURL_MOCK_URL_LOG}"
+  : > "${_CURL_MOCK_AUTH_LOG}"
   cat > "${_CURL_MOCK_DIR}/curl" <<'MOCK'
 #!/usr/bin/env bash
-out=""; url=""; prev=""
+out=""; prev=""
 for arg in "$@"; do
   case "$prev" in
     -H) case "$arg" in Authorization:*) printf '%s\n' "$arg" > "${_CURL_MOCK_AUTH_LOG}" ;; esac ;;
     -o) out="$arg" ;;
   esac
-  case "$arg" in http://*|https://*) url="$arg" ;; esac
   prev="$arg"
 done
-printf '%s\n' "$url" > "${_CURL_MOCK_URL_LOG}"
 [[ -n "$out" ]] && printf '{"ok":true}' > "$out"
 printf '200'
 MOCK
@@ -156,14 +47,98 @@ teardown_curl_mock() {
   rm -rf "${_CURL_MOCK_DIR}"
 }
 
+# ── Lakehouse credential (user/password) ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --user u_blabla --password s_llll >/dev/null 2>&1
+grep -q '^user=u_blabla$' "${CONFIG_FILE}" || fail "configure: expected user=u_blabla in config"
+grep -q '^lakehouse/password=s_llll$' "${CRED_FILE}" || fail "configure: expected lakehouse/password in credentials"
+[[ "$(file_mode "${CRED_FILE}")" == "600" ]] || fail "configure: credentials must be mode 600, got $(file_mode "${CRED_FILE}")"
+pass "configure stores lakehouse user/password (credentials chmod 600)"
+
+# ── Basic token ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --basic-token dG9rZW4= >/dev/null 2>&1
+grep -q '^lakehouse/basic-token=dG9rZW4=$' "${CRED_FILE}" || fail "configure: expected basic-token in credentials"
+pass "configure stores a Basic token"
+
+# ── Management API key (per --env) ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --api-key atm_prod --env production >/dev/null 2>&1
+grep -q '^api-key=atm_prod$' "${CRED_FILE}" || fail "configure: expected api-key in credentials"
+grep -q '^api_key_env=production$' "${CONFIG_FILE}" || fail "configure: expected api_key_env=production in config"
+pass "configure stores an API key with its environment"
+
+# ── Override: a new configure replaces the previous mechanism ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --user u1 --password p1 >/dev/null 2>&1
+"${CLI}" configure --api-key atm_x --env prod >/dev/null 2>&1
+if grep -q '^lakehouse/password=' "${CRED_FILE}"; then fail "override: previous password should be gone"; fi
+if grep -q '^user=' "${CONFIG_FILE}"; then fail "override: previous user should be cleared"; fi
+grep -q '^api-key=atm_x$' "${CRED_FILE}" || fail "override: api-key should be stored"
+pass "a new configure overrides the previous credential (no cumulation)"
+
+# ── Single-mechanism validation ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+if "${CLI}" configure --user u --password p --api-key k --env e >/dev/null 2>&1; then
+  fail "should reject combining mechanisms"
+fi
+pass "configure rejects combining authentication mechanisms"
+if "${CLI}" configure --user u --password p --env prod >/dev/null 2>&1; then
+  fail "--env without --api-key should error"
+fi
+pass "--env is rejected without --api-key"
+if "${CLI}" configure --api-key k >/dev/null 2>&1; then
+  fail "--api-key without --env should error (bashly needs)"
+fi
+pass "--api-key without --env is rejected"
+if "${CLI}" configure --user u >/dev/null 2>&1; then
+  fail "--user without --password should error"
+fi
+pass "--user without --password is rejected"
+
+# ── stdin secrets ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+printf 's_fromstdin' | "${CLI}" configure --user alice --password-stdin >/dev/null 2>&1
+grep -q '^lakehouse/password=s_fromstdin$' "${CRED_FILE}" || fail "--password-stdin should store the piped password"
+pass "--password-stdin reads the password from stdin"
+printf 'atm_fromstdin' | "${CLI}" configure --api-key-stdin --env prod >/dev/null 2>&1
+grep -q '^api-key=atm_fromstdin$' "${CRED_FILE}" || fail "--api-key-stdin should store the piped key"
+pass "--api-key-stdin reads the API key from stdin"
+
+# ── configure --list ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --user u_blabla --password s_llll >/dev/null 2>&1
+OUT="$("${CLI}" configure --list 2>/dev/null)"
+echo "${OUT}" | grep -q 'u_blabla' || fail "--list: should show the username"
+echo "${OUT}" | grep -Eq 'password:[[:space:]]*set' || fail "--list: should show password as set"
+if echo "${OUT}" | grep -q 's_llll'; then fail "--list: must NOT print the secret value"; fi
+echo "${OUT}" | grep -Fq "${CRED_FILE}" || fail "--list: should show the credentials file path as the secret store"
+"${CLI}" configure --list >/dev/null 2>&1 || fail "--list: should exit 0"
+pass "--list shows the stored mechanism, masks secrets, names the secret store, exits 0"
+
+# ── configure --remove ──
+"${CLI}" configure --remove --yes >/dev/null 2>&1
+OUT="$("${CLI}" configure --list 2>/dev/null)"
+echo "${OUT}" | grep -q 'No credentials configured' || fail "--remove should clear the stored credential"
+pass "--remove wipes the stored credential"
+
+# ── interactive ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+printf 'alice\nsecret\n' | "${CLI}" configure >/dev/null 2>&1
+grep -q '^user=alice$' "${CONFIG_FILE}" || fail "interactive: should store the username"
+grep -q '^lakehouse/password=secret$' "${CRED_FILE}" || fail "interactive: should store the password"
+pass "interactive configure stores lakehouse credentials"
+
+# ── stored credentials drive authentication (mock curl) ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
 "${CLI}" configure --user alice --password secret >/dev/null 2>&1
 setup_curl_mock
 "${CLI}" query --statement "SELECT 1" >/dev/null 2>&1
 AUTH="$(cat "${_CURL_MOCK_AUTH_LOG}")"
 EXPECTED="Authorization: Basic $(printf '%s' 'alice:secret' | base64 | tr -d '\n')"
 [[ "${AUTH}" == "${EXPECTED}" ]] || fail "auth: expected stored-cred Basic header, got '${AUTH}'"
-pass "commands authenticate with stored lakehouse credentials"
 teardown_curl_mock
+pass "commands authenticate with stored lakehouse credentials"
 
 setup_curl_mock
 ALTERTABLE_LAKEHOUSE_USERNAME=envuser ALTERTABLE_LAKEHOUSE_PASSWORD=envpass \
@@ -171,19 +146,23 @@ ALTERTABLE_LAKEHOUSE_USERNAME=envuser ALTERTABLE_LAKEHOUSE_PASSWORD=envpass \
 AUTH="$(cat "${_CURL_MOCK_AUTH_LOG}")"
 EXPECTED="Authorization: Basic $(printf '%s' 'envuser:envpass' | base64 | tr -d '\n')"
 [[ "${AUTH}" == "${EXPECTED}" ]] || fail "auth: env vars should beat stored creds, got '${AUTH}'"
+teardown_curl_mock
 pass "environment variables take precedence over stored credentials"
-teardown_curl_mock
 
-"${CLI}" configure --api-base "http://example.test:9999" >/dev/null 2>&1
+# ── refuse to read a credentials file with permissions looser than 600 ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --user u --password p >/dev/null 2>&1
+chmod 644 "${CRED_FILE}"
+ERR="$("${CLI}" configure --list 2>&1 >/dev/null)" && fail "--list should refuse a 644 credentials file"
+echo "${ERR}" | grep -q 'too open' || fail "expected a 'too open' error, got '${ERR}'"
+pass "--list refuses a credentials file looser than 600"
 setup_curl_mock
-"${CLI}" query --statement "SELECT 1" >/dev/null 2>&1
-URL="$(cat "${_CURL_MOCK_URL_LOG}")"
-case "${URL}" in
-  http://example.test:9999/query*) ;;
-  *) fail "base-url: expected stored api_base in URL, got '${URL}'" ;;
-esac
-pass "stored api_base is used as the request base URL"
+if "${CLI}" query --statement "SELECT 1" >/dev/null 2>&1; then fail "query should refuse a 644 credentials file"; fi
 teardown_curl_mock
+pass "commands refuse to use a credentials file looser than 600"
+chmod 600 "${CRED_FILE}"
+"${CLI}" configure --list >/dev/null 2>&1 || fail "--list should accept a 600 credentials file"
+pass "a 600 credentials file is accepted"
 
 echo ""
 echo -e "${GREEN}All configure tests passed.${NC}"

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -164,5 +164,14 @@ chmod 600 "${CRED_FILE}"
 "${CLI}" configure --list >/dev/null 2>&1 || fail "--list should accept a 600 credentials file"
 pass "a 600 credentials file is accepted"
 
+# ── configure --clear (non-interactive full reset) ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --user u --password p >/dev/null 2>&1
+"${CLI}" configure --clear >/dev/null 2>&1 || fail "--clear should exit 0"
+if [[ -f "${CONFIG_FILE}" ]]; then fail "--clear should remove the config file"; fi
+if [[ -f "${CRED_FILE}" ]]; then fail "--clear should remove the credentials file"; fi
+echo "$("${CLI}" configure --list 2>/dev/null)" | grep -q 'No credentials configured' || fail "--clear should leave no credentials"
+pass "--clear removes all stored configuration without prompting"
+
 echo ""
 echo -e "${GREEN}All configure tests passed.${NC}"

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -91,5 +91,30 @@ pass "--list lists configured environments"
 "${CLI}" configure --list >/dev/null 2>&1 || fail "--list: should exit 0 when environments are configured"
 pass "--list exits 0 on success"
 
+# ── Task 5: configure --remove ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --user u --password p >/dev/null 2>&1
+"${CLI}" configure --api-key atm_prod --env production >/dev/null 2>&1
+"${CLI}" configure --api-key atm_stg --env staging >/dev/null 2>&1
+
+"${CLI}" configure --remove --env production --yes >/dev/null 2>&1
+if grep -q '^apikey/production=' "${CRED_FILE}"; then fail "--remove --env: production key should be gone"; fi
+pass "--remove --env removes that environment's API key"
+if grep -q 'production' "${CONFIG_FILE}"; then fail "--remove --env: production should leave config (env list + default)"; fi
+pass "--remove --env drops the env from the list and unsets a matching default"
+
+"${CLI}" configure --remove --lakehouse --yes >/dev/null 2>&1
+if grep -q '^lakehouse/password=' "${CRED_FILE}"; then fail "--remove --lakehouse: password should be gone"; fi
+pass "--remove --lakehouse removes the lakehouse credential"
+
+if "${CLI}" configure --remove >/dev/null 2>&1; then
+  fail "--remove without a target should error"
+fi
+pass "--remove requires an explicit target"
+
+"${CLI}" configure --remove --all --yes >/dev/null 2>&1
+if [[ -f "${CRED_FILE}" ]]; then fail "--remove --all: credentials file should be gone"; fi
+pass "--remove --all clears everything"
+
 echo ""
 echo -e "${GREEN}All configure tests passed.${NC}"

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -116,5 +116,13 @@ pass "--remove requires an explicit target"
 if [[ -f "${CRED_FILE}" ]]; then fail "--remove --all: credentials file should be gone"; fi
 pass "--remove --all clears everything"
 
+# ── Task 6: interactive configure ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+printf 'alice\nsecret\n' | "${CLI}" configure >/dev/null 2>&1
+grep -q '^user=alice$' "${CONFIG_FILE}" || fail "interactive: should store the username"
+pass "interactive configure stores the username"
+grep -q '^lakehouse/password=secret$' "${CRED_FILE}" || fail "interactive: should store the password"
+pass "interactive configure stores the password"
+
 echo ""
 echo -e "${GREEN}All configure tests passed.${NC}"

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -124,5 +124,66 @@ pass "interactive configure stores the username"
 grep -q '^lakehouse/password=secret$' "${CRED_FILE}" || fail "interactive: should store the password"
 pass "interactive configure stores the password"
 
+# ── Task 7: stored credentials & base URL drive requests (offline mock curl) ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+
+setup_curl_mock() {
+  _CURL_MOCK_DIR="$(mktemp -d)"
+  export _CURL_MOCK_AUTH_LOG="${_CURL_MOCK_DIR}/auth.log"
+  export _CURL_MOCK_URL_LOG="${_CURL_MOCK_DIR}/url.log"
+  : > "${_CURL_MOCK_AUTH_LOG}"; : > "${_CURL_MOCK_URL_LOG}"
+  cat > "${_CURL_MOCK_DIR}/curl" <<'MOCK'
+#!/usr/bin/env bash
+out=""; url=""; prev=""
+for arg in "$@"; do
+  case "$prev" in
+    -H) case "$arg" in Authorization:*) printf '%s\n' "$arg" > "${_CURL_MOCK_AUTH_LOG}" ;; esac ;;
+    -o) out="$arg" ;;
+  esac
+  case "$arg" in http://*|https://*) url="$arg" ;; esac
+  prev="$arg"
+done
+printf '%s\n' "$url" > "${_CURL_MOCK_URL_LOG}"
+[[ -n "$out" ]] && printf '{"ok":true}' > "$out"
+printf '200'
+MOCK
+  chmod +x "${_CURL_MOCK_DIR}/curl"
+  _CURL_MOCK_SAVED_PATH="${PATH}"
+  export PATH="${_CURL_MOCK_DIR}:${PATH}"
+}
+teardown_curl_mock() {
+  export PATH="${_CURL_MOCK_SAVED_PATH}"
+  rm -rf "${_CURL_MOCK_DIR}"
+}
+
+"${CLI}" configure --user alice --password secret >/dev/null 2>&1
+setup_curl_mock
+"${CLI}" query --statement "SELECT 1" >/dev/null 2>&1
+AUTH="$(cat "${_CURL_MOCK_AUTH_LOG}")"
+EXPECTED="Authorization: Basic $(printf '%s' 'alice:secret' | base64 | tr -d '\n')"
+[[ "${AUTH}" == "${EXPECTED}" ]] || fail "auth: expected stored-cred Basic header, got '${AUTH}'"
+pass "commands authenticate with stored lakehouse credentials"
+teardown_curl_mock
+
+setup_curl_mock
+ALTERTABLE_LAKEHOUSE_USERNAME=envuser ALTERTABLE_LAKEHOUSE_PASSWORD=envpass \
+  "${CLI}" query --statement "SELECT 1" >/dev/null 2>&1
+AUTH="$(cat "${_CURL_MOCK_AUTH_LOG}")"
+EXPECTED="Authorization: Basic $(printf '%s' 'envuser:envpass' | base64 | tr -d '\n')"
+[[ "${AUTH}" == "${EXPECTED}" ]] || fail "auth: env vars should beat stored creds, got '${AUTH}'"
+pass "environment variables take precedence over stored credentials"
+teardown_curl_mock
+
+"${CLI}" configure --api-base "http://example.test:9999" >/dev/null 2>&1
+setup_curl_mock
+"${CLI}" query --statement "SELECT 1" >/dev/null 2>&1
+URL="$(cat "${_CURL_MOCK_URL_LOG}")"
+case "${URL}" in
+  http://example.test:9999/query*) ;;
+  *) fail "base-url: expected stored api_base in URL, got '${URL}'" ;;
+esac
+pass "stored api_base is used as the request base URL"
+teardown_curl_mock
+
 echo ""
 echo -e "${GREEN}All configure tests passed.${NC}"

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -105,22 +105,16 @@ printf 'atm_fromstdin' | "${CLI}" configure --api-key-stdin --env prod >/dev/nul
 grep -q '^api-key=atm_fromstdin$' "${CRED_FILE}" || fail "--api-key-stdin should store the piped key"
 pass "--api-key-stdin reads the API key from stdin"
 
-# ── configure --list ──
+# ── configure --show ──
 rm -f "${CONFIG_FILE}" "${CRED_FILE}"
 "${CLI}" configure --user u_blabla --password s_llll >/dev/null 2>&1
-OUT="$("${CLI}" configure --list 2>/dev/null)"
-echo "${OUT}" | grep -q 'u_blabla' || fail "--list: should show the username"
-echo "${OUT}" | grep -Eq 'password:[[:space:]]*set' || fail "--list: should show password as set"
-if echo "${OUT}" | grep -q 's_llll'; then fail "--list: must NOT print the secret value"; fi
-echo "${OUT}" | grep -Fq "${CRED_FILE}" || fail "--list: should show the credentials file path as the secret store"
-"${CLI}" configure --list >/dev/null 2>&1 || fail "--list: should exit 0"
-pass "--list shows the stored mechanism, masks secrets, names the secret store, exits 0"
-
-# ── configure --remove ──
-"${CLI}" configure --remove --yes >/dev/null 2>&1
-OUT="$("${CLI}" configure --list 2>/dev/null)"
-echo "${OUT}" | grep -q 'No credentials configured' || fail "--remove should clear the stored credential"
-pass "--remove wipes the stored credential"
+OUT="$("${CLI}" configure --show 2>/dev/null)"
+echo "${OUT}" | grep -q 'u_blabla' || fail "--show: should show the username"
+echo "${OUT}" | grep -Eq 'password:[[:space:]]*set' || fail "--show: should show password as set"
+if echo "${OUT}" | grep -q 's_llll'; then fail "--show: must NOT print the secret value"; fi
+echo "${OUT}" | grep -Fq "${CRED_FILE}" || fail "--show: should show the credentials file path as the secret store"
+"${CLI}" configure --show >/dev/null 2>&1 || fail "--show: should exit 0"
+pass "--show shows the stored mechanism, masks secrets, names the secret store, exits 0"
 
 # ── interactive ──
 rm -f "${CONFIG_FILE}" "${CRED_FILE}"
@@ -153,15 +147,15 @@ pass "environment variables take precedence over stored credentials"
 rm -f "${CONFIG_FILE}" "${CRED_FILE}"
 "${CLI}" configure --user u --password p >/dev/null 2>&1
 chmod 644 "${CRED_FILE}"
-ERR="$("${CLI}" configure --list 2>&1 >/dev/null)" && fail "--list should refuse a 644 credentials file"
+ERR="$("${CLI}" configure --show 2>&1 >/dev/null)" && fail "--show should refuse a 644 credentials file"
 echo "${ERR}" | grep -q 'too open' || fail "expected a 'too open' error, got '${ERR}'"
-pass "--list refuses a credentials file looser than 600"
+pass "--show refuses a credentials file looser than 600"
 setup_curl_mock
 if "${CLI}" query --statement "SELECT 1" >/dev/null 2>&1; then fail "query should refuse a 644 credentials file"; fi
 teardown_curl_mock
 pass "commands refuse to use a credentials file looser than 600"
 chmod 600 "${CRED_FILE}"
-"${CLI}" configure --list >/dev/null 2>&1 || fail "--list should accept a 600 credentials file"
+"${CLI}" configure --show >/dev/null 2>&1 || fail "--show should accept a 600 credentials file"
 pass "a 600 credentials file is accepted"
 
 # ── configure --clear (non-interactive full reset) ──
@@ -170,7 +164,7 @@ rm -f "${CONFIG_FILE}" "${CRED_FILE}"
 "${CLI}" configure --clear >/dev/null 2>&1 || fail "--clear should exit 0"
 if [[ -f "${CONFIG_FILE}" ]]; then fail "--clear should remove the config file"; fi
 if [[ -f "${CRED_FILE}" ]]; then fail "--clear should remove the credentials file"; fi
-echo "$("${CLI}" configure --list 2>/dev/null)" | grep -q 'No credentials configured' || fail "--clear should leave no credentials"
+echo "$("${CLI}" configure --show 2>/dev/null)" | grep -q 'No credentials configured' || fail "--clear should leave no credentials"
 pass "--clear removes all stored configuration without prompting"
 
 echo ""

--- a/tests/configure_test.sh
+++ b/tests/configure_test.sh
@@ -31,5 +31,22 @@ pass "configure stores lakehouse password in credentials (file backend)"
 [[ "$(file_mode "${CRED_FILE}")" == "600" ]] || fail "configure: credentials must be mode 600, got $(file_mode "${CRED_FILE}")"
 pass "credentials file is chmod 600"
 
+# ── Task 2: API key per-environment storage ──
+rm -f "${CONFIG_FILE}" "${CRED_FILE}"
+"${CLI}" configure --api-key atm_prod --env production >/dev/null 2>&1
+grep -q '^apikey/production=atm_prod$' "${CRED_FILE}" || fail "configure: expected apikey/production in credentials"
+pass "configure stores a per-environment API key"
+grep -q '^default_env=production$' "${CONFIG_FILE}" || fail "configure: first env should become default_env"
+pass "first configured environment becomes the default"
+grep -Eq '^environments=.*production' "${CONFIG_FILE}" || fail "configure: environments should list production"
+pass "configure tracks the environment in the environments list"
+
+"${CLI}" configure --api-key atm_stg --env staging >/dev/null 2>&1
+grep -q '^default_env=production$' "${CONFIG_FILE}" || fail "configure: default_env should stay production"
+pass "a second environment does not change the default"
+"${CLI}" configure --api-key atm_stg2 --env staging --default >/dev/null 2>&1
+grep -q '^default_env=staging$' "${CONFIG_FILE}" || fail "configure: --default should switch default_env"
+pass "--default switches the default environment"
+
 echo ""
 echo -e "${GREEN}All configure tests passed.${NC}"


### PR DESCRIPTION
save credentials and allow to show configuration instead of forcing to have env vars

```
# Lakehouse username/password. With no flags you're prompted (password input is hidden):
altertable configure
altertable configure --user your_username --password your_password
printf '%s' "$PASSWORD" | altertable configure --user your_username --password-stdin

# ...or a pre-encoded HTTP Basic token:
altertable configure --basic-token "$(printf '%s' user:pass | base64)"

# ...or a management API key for a given environment:
altertable configure --api-key atm_xxxx --env production
printf '%s' "$KEY" | altertable configure --api-key-stdin --env production

# Inspect (secrets are masked) or clear everything (no prompt):
altertable configure --show
altertable configure --clear
```